### PR TITLE
fix(python): Add missing pinned field to Memory model

### DIFF
--- a/python/src/memoclaw/types.py
+++ b/python/src/memoclaw/types.py
@@ -71,6 +71,7 @@ class Memory(BaseModel):
     access_count: int
     deleted_at: str | None = None
     expires_at: str | None = None
+    pinned: bool = False
 
 
 # ── Recall ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
The Python SDK `Memory` model was missing the `pinned: bool = False` field that exists in the TS SDK types. This adds it for parity.