### PR TITLE
docs: Update README — TypeScript SDK is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Official SDKs for the [MemoClaw](https://memoclaw.com) memory API.
 | Language | Package | Status |
 |----------|---------|--------|
 | Python | [`memoclaw`](./python/) | Available |
-| TypeScript | `@memoclaw/sdk` | Coming soon |
+| TypeScript | [`@memoclaw/sdk`](https://github.com/anajuliabit/memocloud/tree/main/packages/sdk) | Available ([npm](https://www.npmjs.com/package/@memoclaw/sdk)) |
 
 ## What is MemoClaw?
 


### PR DESCRIPTION
The table said TypeScript SDK was 'Coming soon' but it exists as `@memoclaw/sdk` in the monorepo and is published to npm. Updated with links.