### PR TITLE
feat: add CI workflow for Python SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         working-directory: python
         run: |
-          pip install -e ".[test]"
+          pip install -e ".[dev]"
 
       - name: Run tests
         working-directory: python


### PR DESCRIPTION
Adds GitHub Actions CI that runs pytest across Python 3.10–3.13 on push/PR to main. Also runs mypy type checking (non-blocking).