### PR TITLE
feat(typescript): add typed error subclasses

### DIFF
--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -17,21 +17,9 @@ import type {
   SuggestedParams,
   SuggestedResponse,
 } from './types.js';
+import { MemoClawError } from './errors.js';
 
 const DEFAULT_BASE_URL = 'https://api.memoclaw.com';
-
-/** Error thrown by the MemoClaw SDK when the API returns a non-2xx response. */
-export class MemoClawError extends Error {
-  constructor(
-    public readonly status: number,
-    public readonly code: string,
-    message: string,
-    public readonly details?: Record<string, unknown>,
-  ) {
-    super(message);
-    this.name = 'MemoClawError';
-  }
-}
 
 /**
  * Official TypeScript client for the MemoClaw memory API.
@@ -85,7 +73,7 @@ export class MemoClawClient {
       } catch {
         // ignore parse failures
       }
-      throw new MemoClawError(
+      throw MemoClawError.fromResponse(
         res.status,
         errorBody?.error?.code ?? 'UNKNOWN_ERROR',
         errorBody?.error?.message ?? `HTTP ${res.status}`,

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -1,0 +1,98 @@
+/**
+ * Error hierarchy for the MemoClaw TypeScript SDK.
+ *
+ * Mirrors the Python SDK error subclasses so callers can catch specific
+ * error types (e.g. `NotFoundError`, `RateLimitError`) instead of
+ * checking status codes manually.
+ */
+
+/** Base error thrown by the MemoClaw SDK when the API returns a non-2xx response. */
+export class MemoClawError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message: string,
+    public readonly details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = 'MemoClawError';
+  }
+
+  /** Create the most specific error subclass from an HTTP status code. */
+  static fromResponse(
+    status: number,
+    code: string,
+    message: string,
+    details?: Record<string, unknown>,
+  ): MemoClawError {
+    const ErrorClass = STATUS_MAP.get(status) ?? MemoClawError;
+    return new ErrorClass(status, code, message, details);
+  }
+}
+
+/** Raised on 401 responses. */
+export class AuthenticationError extends MemoClawError {
+  constructor(status: number, code: string, message: string, details?: Record<string, unknown>) {
+    super(status, code, message, details);
+    this.name = 'AuthenticationError';
+  }
+}
+
+/** Raised on 402 responses when x402 payment also fails. */
+export class PaymentRequiredError extends MemoClawError {
+  constructor(status: number, code: string, message: string, details?: Record<string, unknown>) {
+    super(status, code, message, details);
+    this.name = 'PaymentRequiredError';
+  }
+}
+
+/** Raised on 403 responses. */
+export class ForbiddenError extends MemoClawError {
+  constructor(status: number, code: string, message: string, details?: Record<string, unknown>) {
+    super(status, code, message, details);
+    this.name = 'ForbiddenError';
+  }
+}
+
+/** Raised on 404 responses. */
+export class NotFoundError extends MemoClawError {
+  constructor(status: number, code: string, message: string, details?: Record<string, unknown>) {
+    super(status, code, message, details);
+    this.name = 'NotFoundError';
+  }
+}
+
+/** Raised on 400/422 responses. */
+export class ValidationError extends MemoClawError {
+  constructor(status: number, code: string, message: string, details?: Record<string, unknown>) {
+    super(status, code, message, details);
+    this.name = 'ValidationError';
+  }
+}
+
+/** Raised on 429 responses. */
+export class RateLimitError extends MemoClawError {
+  constructor(status: number, code: string, message: string, details?: Record<string, unknown>) {
+    super(status, code, message, details);
+    this.name = 'RateLimitError';
+  }
+}
+
+/** Raised on 500 responses. */
+export class InternalServerError extends MemoClawError {
+  constructor(status: number, code: string, message: string, details?: Record<string, unknown>) {
+    super(status, code, message, details);
+    this.name = 'InternalServerError';
+  }
+}
+
+const STATUS_MAP = new Map<number, typeof MemoClawError>([
+  [400, ValidationError],
+  [401, AuthenticationError],
+  [402, PaymentRequiredError],
+  [403, ForbiddenError],
+  [404, NotFoundError],
+  [422, ValidationError],
+  [429, RateLimitError],
+  [500, InternalServerError],
+]);

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,4 +1,14 @@
-export { MemoClawClient, MemoClawError } from './client.js';
+export { MemoClawClient } from './client.js';
+export {
+  MemoClawError,
+  AuthenticationError,
+  PaymentRequiredError,
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+  RateLimitError,
+  InternalServerError,
+} from './errors.js';
 export type {
   MemoClawOptions,
   MemoryType,


### PR DESCRIPTION
Adds specific error subclasses to the TypeScript SDK, matching the Python SDK's error hierarchy.

### New Error Types
| Class | HTTP Status |
|-------|-------------|
| `AuthenticationError` | 401 |
| `PaymentRequiredError` | 402 |
| `ForbiddenError` | 403 |
| `NotFoundError` | 404 |
| `ValidationError` | 400, 422 |
| `RateLimitError` | 429 |
| `InternalServerError` | 500 |

### Usage
```typescript
import { MemoClawClient, NotFoundError, RateLimitError } from '@memoclaw/sdk';

try {
  await client.delete('non-existent-id');
} catch (err) {
  if (err instanceof NotFoundError) {
    console.log('Memory not found');
  } else if (err instanceof RateLimitError) {
    console.log('Rate limited, retry later');
  }
}
```

Based on the `move/typescript-sdk` branch.