### PR TITLE
feat(typescript): add memory_type filter to RecallRequest

### DIFF
--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -50,6 +50,7 @@ export interface RecallRequest {
   filters?: {
     tags?: string[];
     after?: string;
+    memory_type?: MemoryType;
   };
 }
 


### PR DESCRIPTION
Add `memory_type` to `RecallRequest.filters`, allowing TypeScript SDK callers to filter recalled memories by type.

### Usage
```typescript
const results = await client.recall({
  query: 'user preferences',
  filters: { memory_type: 'preference' },
});
```

Companion to the API-side and Python SDK PRs.