### PR TITLE
fix(python): add missing pinned field to Memory and RecallMemory models

### DIFF
--- a/python/src/memoclaw/types.py
+++ b/python/src/memoclaw/types.py
@@ -69,6 +69,7 @@ class Memory(BaseModel):
     updated_at: str
     accessed_at: str
     access_count: int
+    pinned: bool = False
     deleted_at: str | None = None
     expires_at: str | None = None
 
@@ -97,6 +98,7 @@ class RecallMemory(BaseModel):
     namespace: str
     session_id: str | None = None
     agent_id: str | None = None
+    pinned: bool = False
     created_at: str
     access_count: int
     relations: list[RelationWithMemory] | None = None


### PR DESCRIPTION
The API returns `pinned` in both memory list and recall responses, but the Python SDK models were missing it.

### Changes
- Add `pinned: bool = False` to `Memory` model
- Add `pinned: bool = False` to `RecallMemory` model