### PR TITLE
fix(python): add missing pinned field to StoreInput model

### DIFF
--- a/python/src/memoclaw/types.py
+++ b/python/src/memoclaw/types.py
@@ -244,3 +244,4 @@ class StoreInput(BaseModel):
     session_id: str | None = None
     agent_id: str | None = None
     expires_at: str | None = None
+    pinned: bool | None = None


### PR DESCRIPTION
The API accepts `pinned` on store requests but `StoreInput` (used for batch store) was missing it.