### PR TITLE
feat(python): add pinned param to update() and pinned field to types

### DIFF
--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -246,6 +246,7 @@ class MemoClaw:
         memory_type: MemoryType | None = None,
         namespace: str | None = None,
         expires_at: str | None = ...,  # type: ignore[assignment]
+        pinned: bool | None = None,
     ) -> Memory:
         """Update a memory by ID. Only provided fields are updated."""
         body: dict[str, Any] = {}
@@ -262,6 +263,8 @@ class MemoClaw:
         # expires_at uses sentinel so users can pass None to clear it
         if expires_at is not ...:
             body["expires_at"] = expires_at
+        if pinned is not None:
+            body["pinned"] = pinned
 
         data = self._http.request("PATCH", f"/v1/memories/{memory_id}", json=body)
         return Memory.model_validate(data)
@@ -576,6 +579,7 @@ class AsyncMemoClaw:
         memory_type: MemoryType | None = None,
         namespace: str | None = None,
         expires_at: str | None = ...,  # type: ignore[assignment]
+        pinned: bool | None = None,
     ) -> Memory:
         """Update a memory by ID. Only provided fields are updated."""
         body: dict[str, Any] = {}
@@ -591,6 +595,8 @@ class AsyncMemoClaw:
             body["namespace"] = namespace
         if expires_at is not ...:
             body["expires_at"] = expires_at
+        if pinned is not None:
+            body["pinned"] = pinned
 
         data = await self._http.request(
             "PATCH", f"/v1/memories/{memory_id}", json=body

--- a/python/src/memoclaw/types.py
+++ b/python/src/memoclaw/types.py
@@ -71,6 +71,7 @@ class Memory(BaseModel):
     access_count: int
     deleted_at: str | None = None
     expires_at: str | None = None
+    pinned: bool = False
 
 
 # ── Recall ────────────────────────────────────────────────────────────────────
@@ -99,6 +100,7 @@ class RecallMemory(BaseModel):
     agent_id: str | None = None
     created_at: str
     access_count: int
+    pinned: bool = False
     relations: list[RelationWithMemory] | None = None
     signals: RecallSignals | None = Field(default=None, alias="_signals")
 


### PR DESCRIPTION
- Add `pinned` parameter to both sync and async `update()` methods
- Add `pinned` field to `Memory` and `RecallMemory` types to match API response