### PR TITLE
fix: export RelatedMemorySummary from Python SDK

### DIFF
--- a/python/src/memoclaw/__init__.py
+++ b/python/src/memoclaw/__init__.py
@@ -16,6 +16,7 @@ from .errors import (
 )
 from .types import (
     ClusterInfo,
+    RelatedMemorySummary,
     ConsolidateResult,
     DeleteResult,
     ExtractResult,
@@ -63,6 +64,7 @@ __all__ = [
     "RecallResponse",
     "RecallSignals",
     "Relation",
+    "RelatedMemorySummary",
     "RelationsResponse",
     "RelationType",
     "RelationWithMemory",


### PR DESCRIPTION
RelatedMemorySummary is used by RelationWithMemory but wasn't exported from `__init__.py`, making it inaccessible for type annotations.