### PR TITLE
docs: fix MCP server link to correct GitHub org

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ MemoClaw is a semantic memory layer for AI agents. Store, recall, and relate mem
 
 - [Documentation](https://memoclaw.com/docs)
 - [API Reference](https://memoclaw.com/docs/api)
-- [MCP Server](https://github.com/memoclaw/memoclaw-mcp)
+- [MCP Server](https://github.com/anajuliabit/memoclaw-mcp)


### PR DESCRIPTION
Fix MCP server link from `github.com/memoclaw/memoclaw-mcp` to `github.com/anajuliabit/memoclaw-mcp`.