### PR TITLE
fix: remove dead _generateWalletAuth and privateKey code (MEM-30)

### DIFF
--- a/typescript/src/builders.ts
+++ b/typescript/src/builders.ts
@@ -420,7 +420,6 @@ export class AsyncRecallQuery {
   }
 }
 
- */
 export class MemoryFilter {
   private _namespace?: string;
   private _tags?: string[];

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -72,7 +72,6 @@ export type OnErrorHook = (method: string, path: string, error: MemoClawError) =
 export class MemoClawClient {
   private readonly baseUrl: string;
   private readonly wallet: string;
-  private readonly privateKey?: string;
   private readonly _fetch: typeof globalThis.fetch;
   private readonly maxRetries: number;
   private readonly retryDelay: number;
@@ -103,27 +102,6 @@ export class MemoClawClient {
     this._fetch = options.fetch ?? globalThis.fetch;
     this.maxRetries = options.maxRetries ?? 2;
     this.retryDelay = options.retryDelay ?? 500;
-  }
-
-  /** Derive wallet address from private key (simple hex conversion). */
-  private _deriveWalletAddress(privateKey: string): string {
-    // Simple approach: take the last 40 chars of the key hash or use as-is if it looks like an address
-    // For proper Ethereum address derivation, you'd use a library like ethers
-    // This is a placeholder - in production, use proper key derivation
-    const key = privateKey.replace(/^0x/, '');
-    if (key.length === 40) {
-      return '0x' + key;
-    }
-    // For demo purposes, return a placeholder - in real implementation use ethers.js
-    return '0x' + key.slice(-40);
-  }
-
-  /** Generate wallet auth header from private key. */
-  private _generateWalletAuth(): string {
-    const timestamp = Math.floor(Date.now() / 1000).toString();
-    // In production, use ethers.js to sign the message
-    // Format: {address}:{timestamp}:{signature}
-    return `${this.wallet}:${timestamp}:signature`;
   }
 
   /** Register a hook called before each request. Returns this for chaining. */
@@ -167,9 +145,7 @@ export class MemoClawClient {
     }
 
     // Use wallet auth header if private key is provided, otherwise use simple wallet header
-    const headers: Record<string, string> = this.privateKey
-      ? { 'X-Wallet-Auth': this._generateWalletAuth() }
-      : { 'X-Wallet': this.wallet };
+    const headers: Record<string, string> = { 'X-Wallet': this.wallet };
     if (processedBody !== undefined) {
       headers['Content-Type'] = 'application/json';
     }

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -325,8 +325,6 @@ export interface MemoClawErrorBody {
 export interface MemoClawOptions {
   /** Base URL of the MemoClaw API (default: https://api.memoclaw.com) */
   baseUrl?: string;
-  /** Ethereum private key for wallet auth. Generates wallet auth header automatically. */
-  privateKey?: string;
   /** Wallet address for authentication (sent as X-Wallet header).
    *  If omitted, resolved from env MEMOCLAW_WALLET or ~/.memoclaw/config.json. */
   wallet?: string;


### PR DESCRIPTION
## Summary
Removes dead code from the TypeScript SDK:

- **`_generateWalletAuth()`** — returned a literal placeholder string (`${wallet}:${timestamp}:signature`) instead of actual crypto signing. Never functional.
- **`_deriveWalletAddress()`** — stub that just sliced hex chars. Never used properly.
- **`privateKey` option** — declared in types and class but never assigned in constructor, making the `X-Wallet-Auth` header branch permanently unreachable.

Also fixes a stray `*/` in `builders.ts` that broke the build on main.

The Python SDK has a proper `eth_account`-based implementation and is unaffected.

Closes MEM-30