### PR TITLE
ci: add TypeScript tests and type checking to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,27 @@ jobs:
         run: |
           pip install mypy
           mypy src/memoclaw --ignore-missing-imports --no-error-summary || true
+
+  typescript-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["18", "20", "22"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        working-directory: typescript
+        run: npm ci
+
+      - name: Type check
+        working-directory: typescript
+        run: npx tsc --noEmit
+
+      - name: Run tests
+        working-directory: typescript
+        run: npm test


### PR DESCRIPTION
Adds a typescript-tests job to CI that runs on Node 18/20/22:
- `tsc --noEmit` for type checking
- `vitest run` for unit tests (165 tests)

Previously only Python tests were running in CI, meaning TS regressions went undetected.

Closes MEM-66