### PR TITLE
feat: add npm publish workflow for TypeScript SDK

### DIFF
--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -1,0 +1,55 @@
+name: Publish TypeScript SDK to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: typescript
+        run: bun install
+
+      - name: Build
+        working-directory: typescript
+        run: bun run build
+
+      - name: Run tests
+        working-directory: typescript
+        run: bun run test
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: typescript
+        run: bun install
+
+      - name: Build
+        working-directory: typescript
+        run: bun run build
+
+      - name: Publish to npm
+        working-directory: typescript
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -18,7 +18,6 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "prepublishOnly": "bun run build"


### PR DESCRIPTION
Adds a GitHub Actions workflow to publish `@memoclaw/sdk` to npm when a release is published. Mirrors the existing Python PyPI publish workflow.

Also fixes a duplicate `test` script key in `typescript/package.json`.

**Setup required:** Add `NPM_TOKEN` secret and create `npm` environment in repo settings.

Closes MEM-67