### PR TITLE
feat: add batch update method to Python and TypeScript SDKs

### DIFF
--- a/python/src/memoclaw/__init__.py
+++ b/python/src/memoclaw/__init__.py
@@ -51,6 +51,8 @@ from .types import (
     SuggestedMemory,
     SuggestedResponse,
     TypeCount,
+    UpdateBatchResult,
+    UpdateInput,
 )
 from .builders import (
     AsyncMemoryFilter,
@@ -116,6 +118,8 @@ __all__ = [
     "ExportResponse",
     "HistoryEntry",
     "HistoryResponse",
+    "UpdateInput",
+    "UpdateBatchResult",
     "MemoClawConfig",
     "load_config",
     # Builders

--- a/python/src/memoclaw/types.py
+++ b/python/src/memoclaw/types.py
@@ -318,6 +318,28 @@ class HistoryResponse(BaseModel):
 # ── Batch store input ────────────────────────────────────────────────────────
 
 
+class UpdateInput(BaseModel):
+    """Input for a single memory in a batch update request."""
+
+    id: str
+    content: str | None = None
+    metadata: dict[str, Any] | None = None
+    importance: float | None = None
+    memory_type: MemoryType | None = None
+    namespace: str | None = None
+    pinned: bool | None = None
+    expires_at: str | None = None
+
+
+class UpdateBatchResult(BaseModel):
+    """Result of a batch update operation."""
+
+    results: list[dict[str, Any]]
+    updated: int
+    failed: int
+    tokens_used: int
+
+
 class StoreInput(BaseModel):
     """Input for a single memory in a batch store request."""
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -74,4 +74,8 @@ export type {
   ExportResponse,
   HistoryEntry,
   HistoryResponse,
+  UpdateBatchItem,
+  UpdateBatchRequest,
+  UpdateBatchResponse,
+  UpdateBatchResultItem,
 } from './types.js';

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -270,6 +270,36 @@ export interface DeleteRelationResponse {
   id: string;
 }
 
+// ── Update Batch ───────────────────────────────────────
+
+export interface UpdateBatchItem {
+  id: string;
+  content?: string;
+  metadata?: Record<string, unknown>;
+  importance?: number;
+  memory_type?: MemoryType;
+  namespace?: string;
+  pinned?: boolean;
+  expires_at?: string | null;
+}
+
+export interface UpdateBatchRequest {
+  updates: UpdateBatchItem[];
+}
+
+export interface UpdateBatchResultItem {
+  id: string;
+  updated: boolean;
+  error?: string;
+}
+
+export interface UpdateBatchResponse {
+  results: UpdateBatchResultItem[];
+  updated: number;
+  failed: number;
+  tokens_used: number;
+}
+
 // ── Delete Batch ───────────────────────────────────────
 
 export interface DeleteBatchResult {


### PR DESCRIPTION
## Summary
Adds `updateBatch` (TS) / `update_batch` (Python) method to both SDKs, calling `POST /v1/memories/batch-update`.

## Changes
- **TypeScript**: New `updateBatch(updates)` method on `MemoClawClient`, new types `UpdateBatchItem`, `UpdateBatchRequest`, `UpdateBatchResponse`, `UpdateBatchResultItem`
- **Python**: New `update_batch(updates)` method on both `MemoClaw` and `AsyncMemoClaw`, new types `UpdateInput`, `UpdateBatchResult`
- Validates: non-empty array, max 100 items, each item has non-empty `id`
- Supports both dict and typed input (`UpdateInput` model)
- Full test coverage (sync + async)

Closes MEM-94