### PR TITLE
fix: add missing input validation for delete, relations, and deleteBatch signal

### DIFF
--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -473,6 +473,7 @@ class MemoClaw:
 
     def delete(self, memory_id: str) -> DeleteResult:
         """Delete a memory by ID."""
+        _validate_non_empty(memory_id, "memory_id")
         data = self._run_request("DELETE", f"/v1/memories/{quote(memory_id, safe='')}")
         return DeleteResult.model_validate(data)
 
@@ -612,6 +613,8 @@ class MemoClaw:
         metadata: dict[str, Any] | None = None,
     ) -> Relation:
         """Create a relationship between two memories."""
+        _validate_non_empty(memory_id, "memory_id")
+        _validate_non_empty(target_id, "target_id")
         body: dict[str, Any] = {
             "target_id": target_id,
             "relation_type": relation_type,
@@ -625,12 +628,15 @@ class MemoClaw:
 
     def list_relations(self, memory_id: str) -> list[RelationWithMemory]:
         """List all relationships for a memory."""
+        _validate_non_empty(memory_id, "memory_id")
         data = self._run_request("GET", f"/v1/memories/{quote(memory_id, safe='')}/relations")
         resp = RelationsResponse.model_validate(data)
         return resp.relations  # type: ignore[return-value]
 
     def delete_relation(self, memory_id: str, relation_id: str) -> DeleteResult:
         """Delete a memory relationship."""
+        _validate_non_empty(memory_id, "memory_id")
+        _validate_non_empty(relation_id, "relation_id")
         data = self._run_request(
             "DELETE", f"/v1/memories/{quote(memory_id, safe='')}/relations/{quote(relation_id, safe='')}"
         )
@@ -1287,6 +1293,7 @@ class AsyncMemoClaw:
 
     async def delete(self, memory_id: str) -> DeleteResult:
         """Delete a memory by ID."""
+        _validate_non_empty(memory_id, "memory_id")
         data = await self._run_request("DELETE", f"/v1/memories/{quote(memory_id, safe='')}")
         return DeleteResult.model_validate(data)
 
@@ -1428,6 +1435,8 @@ class AsyncMemoClaw:
         metadata: dict[str, Any] | None = None,
     ) -> Relation:
         """Create a relationship between two memories."""
+        _validate_non_empty(memory_id, "memory_id")
+        _validate_non_empty(target_id, "target_id")
         body: dict[str, Any] = {
             "target_id": target_id,
             "relation_type": relation_type,
@@ -1441,6 +1450,7 @@ class AsyncMemoClaw:
 
     async def list_relations(self, memory_id: str) -> list[RelationWithMemory]:
         """List all relationships for a memory."""
+        _validate_non_empty(memory_id, "memory_id")
         data = await self._run_request(
             "GET", f"/v1/memories/{quote(memory_id, safe='')}/relations"
         )
@@ -1451,6 +1461,8 @@ class AsyncMemoClaw:
         self, memory_id: str, relation_id: str
     ) -> DeleteResult:
         """Delete a memory relationship."""
+        _validate_non_empty(memory_id, "memory_id")
+        _validate_non_empty(relation_id, "relation_id")
         data = await self._run_request(
             "DELETE", f"/v1/memories/{quote(memory_id, safe='')}/relations/{quote(relation_id, safe='')}"
         )

--- a/python/tests/test_validation.py
+++ b/python/tests/test_validation.py
@@ -48,6 +48,35 @@ class TestSyncValidation:
             client.store_batch(memories)
 
 
+    def test_delete_empty_id(self, client: MemoClaw):
+        with pytest.raises(ValueError, match="memory_id"):
+            client.delete("")
+
+    def test_delete_whitespace_id(self, client: MemoClaw):
+        with pytest.raises(ValueError, match="memory_id"):
+            client.delete("   ")
+
+    def test_create_relation_empty_memory_id(self, client: MemoClaw):
+        with pytest.raises(ValueError, match="memory_id"):
+            client.create_relation("", "target-id", "related_to")
+
+    def test_create_relation_empty_target_id(self, client: MemoClaw):
+        with pytest.raises(ValueError, match="target_id"):
+            client.create_relation("mem-id", "", "related_to")
+
+    def test_list_relations_empty_id(self, client: MemoClaw):
+        with pytest.raises(ValueError, match="memory_id"):
+            client.list_relations("")
+
+    def test_delete_relation_empty_memory_id(self, client: MemoClaw):
+        with pytest.raises(ValueError, match="memory_id"):
+            client.delete_relation("", "rel-id")
+
+    def test_delete_relation_empty_relation_id(self, client: MemoClaw):
+        with pytest.raises(ValueError, match="relation_id"):
+            client.delete_relation("mem-id", "")
+
+
 class TestAsyncValidation:
     @pytest.mark.asyncio
     async def test_store_empty_content(self, async_client: AsyncMemoClaw):
@@ -74,3 +103,30 @@ class TestAsyncValidation:
         memories = [{"content": f"mem {i}"} for i in range(101)]
         with pytest.raises(ValueError, match="exceeds maximum"):
             await async_client.store_batch(memories)
+
+    @pytest.mark.asyncio
+    async def test_delete_empty_id(self, async_client: AsyncMemoClaw):
+        with pytest.raises(ValueError, match="memory_id"):
+            await async_client.delete("")
+
+    @pytest.mark.asyncio
+    async def test_create_relation_empty_memory_id(self, async_client: AsyncMemoClaw):
+        with pytest.raises(ValueError, match="memory_id"):
+            await async_client.create_relation("", "target-id", "related_to")
+
+    @pytest.mark.asyncio
+    async def test_create_relation_empty_target_id(self, async_client: AsyncMemoClaw):
+        with pytest.raises(ValueError, match="target_id"):
+            await async_client.create_relation("mem-id", "", "related_to")
+
+    @pytest.mark.asyncio
+    async def test_list_relations_empty_id(self, async_client: AsyncMemoClaw):
+        with pytest.raises(ValueError, match="memory_id"):
+            await async_client.list_relations("")
+
+    @pytest.mark.asyncio
+    async def test_delete_relation_empty_ids(self, async_client: AsyncMemoClaw):
+        with pytest.raises(ValueError, match="memory_id"):
+            await async_client.delete_relation("", "rel-id")
+        with pytest.raises(ValueError, match="relation_id"):
+            await async_client.delete_relation("mem-id", "")

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -355,7 +355,7 @@ export class MemoClawClient {
   }
 
   /** Delete multiple memories by ID in batch. */
-  async deleteBatch(ids: string[]): Promise<import('./types.js').DeleteBatchResult[]> {
+  async deleteBatch(ids: string[], options?: { signal?: AbortSignal }): Promise<import('./types.js').DeleteBatchResult[]> {
     const results: import('./types.js').DeleteBatchResult[] = [];
     // Process in chunks of 50
     for (let i = 0; i < ids.length; i += 50) {
@@ -363,7 +363,9 @@ export class MemoClawClient {
       const response = await this.request<{ results: import('./types.js').DeleteBatchResult[] }>(
         'POST',
         '/v1/memories/batch-delete',
-        { ids: chunk }
+        { ids: chunk },
+        undefined,
+        options?.signal,
       );
       results.push(...response.results);
     }


### PR DESCRIPTION
## Changes

### Python SDK
- Add `_validate_non_empty` checks to `delete()`, `create_relation()`, `list_relations()`, and `delete_relation()` for both sync (`MemoClaw`) and async (`AsyncMemoClaw`) clients
- These methods were missing validation that exists in their TS counterparts and in other Python methods like `get()`, `update()`, `get_history()`

### TypeScript SDK  
- Add `AbortSignal` support to `deleteBatch()` via optional `options` parameter, consistent with all other client methods

### Tests
- 12 new validation tests covering all fixed methods (sync + async)