### PR TITLE
feat: expose immutable memory support in SDK types

### DIFF
--- a/python/src/memoclaw/builders.py
+++ b/python/src/memoclaw/builders.py
@@ -44,6 +44,7 @@ class MemoryBuilder:
         self._agent_id: str | None = None
         self._expires_at: str | None = None
         self._pinned: bool | None = None
+        self._immutable: bool | None = None
         self._metadata: dict[str, Any] | None = None
 
     def content(self, content: str) -> MemoryBuilder:
@@ -107,6 +108,11 @@ class MemoryBuilder:
         self._pinned = pinned
         return self
 
+    def immutable(self, immutable: bool = True) -> MemoryBuilder:
+        """Set immutable status (prevents future modifications)."""
+        self._immutable = immutable
+        return self
+
     def metadata(self, metadata: dict[str, Any]) -> MemoryBuilder:
         """Set custom metadata."""
         self._metadata = metadata
@@ -133,6 +139,7 @@ class MemoryBuilder:
             agent_id=self._agent_id,
             expires_at=self._expires_at,
             pinned=self._pinned,
+            immutable=self._immutable,
             metadata=self._metadata,
         )
 
@@ -712,6 +719,7 @@ class StoreBuilder:
         self._agent_id: str | None = None
         self._expires_at: str | None = None
         self._pinned: bool | None = None
+        self._immutable: bool | None = None
         self._metadata: dict[str, Any] | None = None
 
     def content(self, content: str) -> StoreBuilder:
@@ -768,6 +776,11 @@ class StoreBuilder:
         self._pinned = pinned
         return self
 
+    def immutable(self, immutable: bool = True) -> StoreBuilder:
+        """Make the memory immutable (prevents future modifications)."""
+        self._immutable = immutable
+        return self
+
     def metadata(self, metadata: dict[str, Any]) -> StoreBuilder:
         """Set custom metadata."""
         self._metadata = metadata
@@ -787,6 +800,7 @@ class StoreBuilder:
             agent_id=self._agent_id,
             expires_at=self._expires_at,
             pinned=self._pinned,
+            immutable=self._immutable,
             metadata=self._metadata,
         )
 
@@ -805,6 +819,7 @@ class AsyncStoreBuilder:
         self._agent_id: str | None = None
         self._expires_at: str | None = None
         self._pinned: bool | None = None
+        self._immutable: bool | None = None
         self._metadata: dict[str, Any] | None = None
 
     def content(self, content: str) -> AsyncStoreBuilder:
@@ -851,6 +866,10 @@ class AsyncStoreBuilder:
         self._pinned = pinned
         return self
 
+    def immutable(self, immutable: bool = True) -> AsyncStoreBuilder:
+        self._immutable = immutable
+        return self
+
     def metadata(self, metadata: dict[str, Any]) -> AsyncStoreBuilder:
         self._metadata = metadata
         return self
@@ -868,6 +887,7 @@ class AsyncStoreBuilder:
             agent_id=self._agent_id,
             expires_at=self._expires_at,
             pinned=self._pinned,
+            immutable=self._immutable,
             metadata=self._metadata,
         )
 

--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -94,6 +94,7 @@ def _build_store_body(
     agent_id: str | None,
     expires_at: str | None,
     pinned: bool | None,
+    immutable: bool | None,
     metadata: dict[str, Any] | None,
 ) -> dict[str, Any]:
     body: dict[str, Any] = {"content": content}
@@ -111,6 +112,8 @@ def _build_store_body(
         body["expires_at"] = expires_at
     if pinned is not None:
         body["pinned"] = pinned
+    if immutable is not None:
+        body["immutable"] = immutable
     if tags is not None or metadata is not None:
         md: dict[str, Any] = metadata.copy() if metadata else {}
         if tags is not None:
@@ -241,6 +244,7 @@ class MemoClaw:
         agent_id: str | None = None,
         expires_at: str | None = None,
         pinned: bool | None = None,
+        immutable: bool | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> StoreResult:
         """Store a memory."""
@@ -255,6 +259,7 @@ class MemoClaw:
             agent_id=agent_id,
             expires_at=expires_at,
             pinned=pinned,
+            immutable=immutable,
             metadata=metadata,
         )
         data = self._run_request("POST", "/v1/store", json=body)
@@ -408,6 +413,7 @@ class MemoClaw:
         memory_type: MemoryType | None = None,
         namespace: str | None = None,
         pinned: bool | None = None,
+        immutable: bool | None = None,
         expires_at: str | None = ...,  # type: ignore[assignment]
     ) -> Memory:
         """Update a memory by ID. Only provided fields are updated."""
@@ -424,6 +430,8 @@ class MemoClaw:
             body["namespace"] = namespace
         if pinned is not None:
             body["pinned"] = pinned
+        if immutable is not None:
+            body["immutable"] = immutable
         # expires_at uses sentinel so users can pass None to clear it
         if expires_at is not ...:
             body["expires_at"] = expires_at
@@ -1057,6 +1065,7 @@ class AsyncMemoClaw:
         agent_id: str | None = None,
         expires_at: str | None = None,
         pinned: bool | None = None,
+        immutable: bool | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> StoreResult:
         """Store a memory."""
@@ -1071,6 +1080,7 @@ class AsyncMemoClaw:
             agent_id=agent_id,
             expires_at=expires_at,
             pinned=pinned,
+            immutable=immutable,
             metadata=metadata,
         )
         data = await self._run_request("POST", "/v1/store", json=body)
@@ -1227,6 +1237,7 @@ class AsyncMemoClaw:
         memory_type: MemoryType | None = None,
         namespace: str | None = None,
         pinned: bool | None = None,
+        immutable: bool | None = None,
         expires_at: str | None = ...,  # type: ignore[assignment]
     ) -> Memory:
         """Update a memory by ID. Only provided fields are updated."""

--- a/python/src/memoclaw/types.py
+++ b/python/src/memoclaw/types.py
@@ -72,6 +72,7 @@ class Memory(BaseModel):
     deleted_at: str | None = None
     expires_at: str | None = None
     pinned: bool = False
+    immutable: bool = False
 
 
 # ── Recall ────────────────────────────────────────────────────────────────────
@@ -99,6 +100,7 @@ class RecallMemory(BaseModel):
     session_id: str | None = None
     agent_id: str | None = None
     pinned: bool = False
+    immutable: bool = False
     created_at: str
     access_count: int
     relations: list[RelationWithMemory] | None = None
@@ -328,6 +330,7 @@ class UpdateInput(BaseModel):
     memory_type: MemoryType | None = None
     namespace: str | None = None
     pinned: bool | None = None
+    immutable: bool | None = None
     expires_at: str | None = None
 
 
@@ -367,3 +370,4 @@ class StoreInput(BaseModel):
     agent_id: str | None = None
     expires_at: str | None = None
     pinned: bool | None = None
+    immutable: bool | None = None

--- a/typescript/src/__tests__/client.test.ts
+++ b/typescript/src/__tests__/client.test.ts
@@ -107,7 +107,7 @@ describe('MemoClawClient', () => {
 
   describe('get', () => {
     it('retrieves a single memory', async () => {
-      const mem = { id: 'mem-1', user_id: 'u1', namespace: 'default', content: 'hello', embedding_model: 'e', metadata: {}, importance: 0.5, memory_type: 'general', session_id: null, agent_id: null, created_at: '', updated_at: '', accessed_at: '', access_count: 0, deleted_at: null, expires_at: null, pinned: false };
+      const mem = { id: 'mem-1', user_id: 'u1', namespace: 'default', content: 'hello', embedding_model: 'e', metadata: {}, importance: 0.5, memory_type: 'general', session_id: null, agent_id: null, created_at: '', updated_at: '', accessed_at: '', access_count: 0, deleted_at: null, expires_at: null, pinned: false, immutable: false };
       const f = mockFetch([{ status: 200, body: mem }]);
       const client = createClient(f);
       const result = await client.get('mem-1');
@@ -117,7 +117,7 @@ describe('MemoClawClient', () => {
 
   describe('update', () => {
     it('sends PATCH /v1/memories/:id', async () => {
-      const mem = { id: 'mem-1', user_id: 'u1', namespace: 'default', content: 'updated', embedding_model: 'e', metadata: {}, importance: 0.9, memory_type: 'general', session_id: null, agent_id: null, created_at: '', updated_at: '', accessed_at: '', access_count: 0, deleted_at: null, expires_at: null, pinned: false };
+      const mem = { id: 'mem-1', user_id: 'u1', namespace: 'default', content: 'updated', embedding_model: 'e', metadata: {}, importance: 0.9, memory_type: 'general', session_id: null, agent_id: null, created_at: '', updated_at: '', accessed_at: '', access_count: 0, deleted_at: null, expires_at: null, pinned: false, immutable: false };
       const f = mockFetch([{ status: 200, body: mem }]);
       const client = createClient(f);
       const result = await client.update('mem-1', { content: 'updated', importance: 0.9 });

--- a/typescript/src/builders.test.ts
+++ b/typescript/src/builders.test.ts
@@ -47,7 +47,7 @@ describe('RecallQuery', () => {
           agent_id: null,
           created_at: '2025-01-01T00:00:00Z',
           access_count: 1,
-          pinned: false,
+          pinned: false, immutable: false,
         },
       ],
       query_tokens: 5,
@@ -140,7 +140,7 @@ describe('MemoryFilter', () => {
       access_count: 0,
       deleted_at: null,
       expires_at: null,
-      pinned: false,
+      pinned: false, immutable: false,
     };
 
     mockFetch.mockResolvedValue({
@@ -391,7 +391,7 @@ describe('AsyncMemoryFilter', () => {
       access_count: 0,
       deleted_at: null,
       expires_at: null,
-      pinned: false,
+      pinned: false, immutable: false,
     };
 
     mockFetch.mockResolvedValue({
@@ -643,7 +643,7 @@ describe('MemoClawClient Extensions', () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({
-          memories: [{ id: 'm1', content: 'Test', metadata: {}, importance: 0.5, memory_type: 'general', namespace: 'default', session_id: null, agent_id: null, created_at: '2025-01-01', access_count: 0, pinned: false }],
+          memories: [{ id: 'm1', content: 'Test', metadata: {}, importance: 0.5, memory_type: 'general', namespace: 'default', session_id: null, agent_id: null, created_at: '2025-01-01', access_count: 0, pinned: false, immutable: false }],
           total: 1,
           limit: 50,
           offset: 0,
@@ -718,7 +718,7 @@ describe('AsyncRecallQuery', () => {
           agent_id: null,
           created_at: '2025-01-01T00:00:00Z',
           access_count: 1,
-          pinned: false,
+          pinned: false, immutable: false,
         },
       ],
       query_tokens: 5,
@@ -799,7 +799,7 @@ describe('AsyncRecallQuery', () => {
           agent_id: null,
           created_at: '2025-01-01T00:00:00Z',
           access_count: 1,
-          pinned: false,
+          pinned: false, immutable: false,
         },
         {
           id: 'm2',
@@ -813,7 +813,7 @@ describe('AsyncRecallQuery', () => {
           agent_id: null,
           created_at: '2025-01-01T00:00:00Z',
           access_count: 1,
-          pinned: false,
+          pinned: false, immutable: false,
         },
       ],
       query_tokens: 5,

--- a/typescript/src/builders.ts
+++ b/typescript/src/builders.ts
@@ -46,6 +46,7 @@ export class MemoryBuilder {
   private _agentId?: string;
   private _expiresAt?: string;
   private _pinned?: boolean;
+  private _immutable?: boolean;
   private _metadata?: Record<string, unknown>;
 
   /**
@@ -143,6 +144,14 @@ export class MemoryBuilder {
   }
 
   /**
+   * Set immutable status (prevents future modifications).
+   */
+  immutable(immutable: boolean = true): this {
+    this._immutable = immutable;
+    return this;
+  }
+
+  /**
    * Set custom metadata.
    */
   metadata(metadata: Record<string, unknown>): this {
@@ -177,6 +186,7 @@ export class MemoryBuilder {
       agent_id: this._agentId,
       expires_at: this._expiresAt,
       pinned: this._pinned,
+      immutable: this._immutable,
       metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
     };
   }
@@ -687,6 +697,7 @@ export class StoreBuilder {
   private _agentId?: string;
   private _expiresAt?: string;
   private _pinned?: boolean;
+  private _immutable?: boolean;
   private _metadata?: Record<string, unknown>;
 
   constructor(private client: MemoClawClient) {}
@@ -757,6 +768,12 @@ export class StoreBuilder {
     return this;
   }
 
+  /** Make the memory immutable (prevents future modifications). */
+  immutable(immutable = true): StoreBuilder {
+    this._immutable = immutable;
+    return this;
+  }
+
   /** Set custom metadata. */
   metadata(metadata: Record<string, unknown>): StoreBuilder {
     this._metadata = metadata;
@@ -777,6 +794,7 @@ export class StoreBuilder {
     if (this._agentId) request.agent_id = this._agentId;
     if (this._expiresAt) request.expires_at = this._expiresAt;
     if (this._pinned !== undefined) request.pinned = this._pinned;
+    if (this._immutable !== undefined) request.immutable = this._immutable;
     if (this._metadata) request.metadata = { ...request.metadata, ...this._metadata };
     return this.client.store(request);
   }

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -16,6 +16,7 @@ export interface StoreRequest {
   agent_id?: string;
   expires_at?: string;
   pinned?: boolean;
+  immutable?: boolean;
 }
 
 export interface StoreResponse {
@@ -78,6 +79,7 @@ export interface RecallMemory {
   created_at: string;
   access_count: number;
   pinned: boolean;
+  immutable: boolean;
   relations?: RelationWithMemory[];
   _signals?: RecallSignals;
 }
@@ -107,6 +109,7 @@ export interface Memory {
   deleted_at: string | null;
   expires_at: string | null;
   pinned: boolean;
+  immutable: boolean;
 }
 
 export interface ListMemoriesResponse {
@@ -133,6 +136,7 @@ export interface UpdateMemoryRequest {
   namespace?: string;
   expires_at?: string | null;
   pinned?: boolean;
+  immutable?: boolean;
 }
 
 // ── Delete ─────────────────────────────────────────────
@@ -280,6 +284,7 @@ export interface UpdateBatchItem {
   memory_type?: MemoryType;
   namespace?: string;
   pinned?: boolean;
+  immutable?: boolean;
   expires_at?: string | null;
 }
 

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -102,7 +102,7 @@ describe('recall', () => {
     const f = mockFetch([{
       status: 200,
       body: {
-        memories: [{ id: 'm1', content: 'test', similarity: 0.95, metadata: {}, importance: 0.8, memory_type: 'general', namespace: 'default', session_id: null, agent_id: null, created_at: '2025-01-01', access_count: 1, pinned: false }],
+        memories: [{ id: 'm1', content: 'test', similarity: 0.95, metadata: {}, importance: 0.8, memory_type: 'general', namespace: 'default', session_id: null, agent_id: null, created_at: '2025-01-01', access_count: 1, pinned: false, immutable: false }],
         query_tokens: 5,
       },
     }]);
@@ -132,7 +132,7 @@ describe('list', () => {
 
 describe('get', () => {
   it('gets a memory by id', async () => {
-    const mem = { id: 'mem-1', user_id: 'u1', namespace: 'default', content: 'test', embedding_model: 'text-embedding-3-small', metadata: {}, importance: 0.5, memory_type: 'general', session_id: null, agent_id: null, created_at: '2025-01-01', updated_at: '2025-01-01', accessed_at: '2025-01-01', access_count: 0, deleted_at: null, expires_at: null, pinned: false };
+    const mem = { id: 'mem-1', user_id: 'u1', namespace: 'default', content: 'test', embedding_model: 'text-embedding-3-small', metadata: {}, importance: 0.5, memory_type: 'general', session_id: null, agent_id: null, created_at: '2025-01-01', updated_at: '2025-01-01', accessed_at: '2025-01-01', access_count: 0, deleted_at: null, expires_at: null, pinned: false, immutable: false };
     const f = mockFetch([{ status: 200, body: mem }]);
     const client = createClient(f);
     const result = await client.get('mem-1');
@@ -164,7 +164,7 @@ describe('delete', () => {
 
 describe('update', () => {
   it('updates a memory', async () => {
-    const mem = { id: 'mem-1', user_id: 'u1', namespace: 'default', content: 'updated', embedding_model: 'text-embedding-3-small', metadata: {}, importance: 0.9, memory_type: 'general', session_id: null, agent_id: null, created_at: '2025-01-01', updated_at: '2025-06-01', accessed_at: '2025-01-01', access_count: 1, deleted_at: null, expires_at: null, pinned: false };
+    const mem = { id: 'mem-1', user_id: 'u1', namespace: 'default', content: 'updated', embedding_model: 'text-embedding-3-small', metadata: {}, importance: 0.9, memory_type: 'general', session_id: null, agent_id: null, created_at: '2025-01-01', updated_at: '2025-06-01', accessed_at: '2025-01-01', access_count: 1, deleted_at: null, expires_at: null, pinned: false, immutable: false };
     const f = mockFetch([{ status: 200, body: mem }]);
     const client = createClient(f);
     const result = await client.update('mem-1', { content: 'updated', importance: 0.9 });
@@ -355,7 +355,7 @@ describe('retry logic', () => {
 
 describe('iterMemories', () => {
   it('auto-paginates through all memories', async () => {
-    const makeMem = (id: string) => ({ id, user_id: 'u1', namespace: 'default', content: 'test', embedding_model: 'e', metadata: {}, importance: 0.5, memory_type: 'general', session_id: null, agent_id: null, created_at: '2025-01-01', updated_at: '2025-01-01', accessed_at: '2025-01-01', access_count: 0, deleted_at: null, expires_at: null, pinned: false });
+    const makeMem = (id: string) => ({ id, user_id: 'u1', namespace: 'default', content: 'test', embedding_model: 'e', metadata: {}, importance: 0.5, memory_type: 'general', session_id: null, agent_id: null, created_at: '2025-01-01', updated_at: '2025-01-01', accessed_at: '2025-01-01', access_count: 0, deleted_at: null, expires_at: null, pinned: false, immutable: false });
     const f = mockFetch([
       { status: 200, body: { memories: [makeMem('m1'), makeMem('m2')], total: 3, limit: 2, offset: 0 } },
       { status: 200, body: { memories: [makeMem('m3')], total: 3, limit: 2, offset: 2 } },


### PR DESCRIPTION
Add `immutable` field to store/update request types and response types in both Python and TypeScript SDKs.

**Changes:**
- `StoreRequest`/`StoreInput`: added `immutable?: boolean`
- `UpdateMemoryRequest`/`UpdateInput`: added `immutable?: boolean`
- `Memory`/`RecallMemory` response types: added `immutable` field
- Builders (`MemoryBuilder`, `StoreBuilder`, `AsyncStoreBuilder`): added `.immutable()` method
- Python client `store`/`update` methods: added `immutable` parameter

All existing tests pass + updated test fixtures.

Closes MEM-119