### PR TITLE
fix(python): add missing immutable field to AsyncMemoClaw.update()

### DIFF
--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -1278,6 +1278,8 @@ class AsyncMemoClaw:
             body["namespace"] = namespace
         if pinned is not None:
             body["pinned"] = pinned
+        if immutable is not None:
+            body["immutable"] = immutable
         if expires_at is not ...:
             body["expires_at"] = expires_at
 


### PR DESCRIPTION
## Bug Fix

The `AsyncMemoClaw.update()` method was missing the `immutable` parameter in request body construction. The sync `MemoClaw.update()` correctly included it.

**Impact:** Calling `await client.update(id, immutable=True)` on the async client would silently ignore the `immutable` flag.

**Fix:** Added the missing `if immutable is not None: body['immutable'] = immutable` line.

All 184 Python tests pass.