### PR TITLE
feat(ts): add request timeout support

### DIFF
--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -497,4 +497,9 @@ export interface MemoClawOptions {
   retryDelay?: number;
   /** Path to config file (default: ~/.memoclaw/config.json) */
   configPath?: string;
+  /** Default request timeout in milliseconds. When set, each request will
+   *  be aborted if it hasn't completed within this duration. Per-request
+   *  `signal` options take precedence over (and are combined with) this
+   *  default via `AbortSignal.any`. Pass `0` to disable. */
+  timeout?: number;
 }


### PR DESCRIPTION
## Summary
Add client-level `timeout` option to the TypeScript SDK, bringing parity with the Python SDK.

### Changes
- New `timeout` option in `MemoClawOptions` (milliseconds, default: 0 = disabled)
- Combines with per-request `signal` via `AbortSignal.any()`
- `TimeoutError` is not retried (same as `AbortError`)
- 3 new tests covering timeout abort, within-timeout success, and signal+timeout combo

### Usage
```ts
const client = new MemoClawClient({
  wallet: '0x...',
  timeout: 10_000, // 10 second timeout
});
```

Closes MEM-160