### PR TITLE
fix: align TS SDK auth header with API spec (x-wallet-auth)

### DIFF
--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -186,7 +186,7 @@ export class MemoClawClient {
     } else {
       walletHeader = this.wallet;
     }
-    const headers: Record<string, string> = { 'X-Wallet': walletHeader };
+    const headers: Record<string, string> = { 'x-wallet-auth': walletHeader };
     if (processedBody !== undefined) {
       headers['Content-Type'] = 'application/json';
     }

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -481,12 +481,12 @@ export interface MemoClawErrorBody {
 export interface MemoClawOptions {
   /** Base URL of the MemoClaw API (default: https://api.memoclaw.com) */
   baseUrl?: string;
-  /** Wallet address for authentication (sent as X-Wallet header).
+  /** Wallet address for authentication (sent as x-wallet-auth header).
    *  If omitted, resolved from env MEMOCLAW_WALLET or ~/.memoclaw/config.json.
    *  When privateKey is provided, the wallet address is derived automatically. */
   wallet?: string;
   /** Ethereum private key for cryptographic wallet signature auth.
-   *  When provided, the X-Wallet header uses the format `address:timestamp:signature`
+   *  When provided, the x-wallet-auth header uses the format `address:timestamp:signature`
    *  matching the Python SDK behavior. If omitted, falls back to plain wallet address. */
   privateKey?: string;
   /** Optional fetch implementation (defaults to globalThis.fetch) */

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -66,7 +66,7 @@ describe('store', () => {
     const client = createClient(f);
     await client.store({ content: 'test' });
     const [, init] = f.mock.calls[0]!;
-    expect(init.headers['X-Wallet']).toBe(WALLET);
+    expect(init.headers['x-wallet-auth']).toBe(WALLET);
     expect(init.headers['Content-Type']).toBe('application/json');
     expect(init.method).toBe('POST');
   });
@@ -391,7 +391,7 @@ describe('wallet signature auth', () => {
     const client = new MemoClawClient({ privateKey: TEST_PRIVATE_KEY, fetch: f });
     await client.store({ content: 'test' });
     const [, init] = f.mock.calls[0]!;
-    const walletHeader = init.headers['X-Wallet'] as string;
+    const walletHeader = init.headers['x-wallet-auth'] as string;
     expect(walletHeader).toContain(TEST_ADDRESS);
   });
 
@@ -400,7 +400,7 @@ describe('wallet signature auth', () => {
     const client = new MemoClawClient({ privateKey: TEST_PRIVATE_KEY, fetch: f });
     await client.store({ content: 'test' });
     const [, init] = f.mock.calls[0]!;
-    const walletHeader = init.headers['X-Wallet'] as string;
+    const walletHeader = init.headers['x-wallet-auth'] as string;
     const parts = walletHeader.split(':');
     expect(parts).toHaveLength(3);
     expect(parts[0]).toBe(TEST_ADDRESS);
@@ -413,7 +413,7 @@ describe('wallet signature auth', () => {
     const client = new MemoClawClient({ wallet: WALLET, fetch: f });
     await client.store({ content: 'test' });
     const [, init] = f.mock.calls[0]!;
-    expect(init.headers['X-Wallet']).toBe(WALLET);
+    expect(init.headers['x-wallet-auth']).toBe(WALLET);
   });
 
   it('prefers explicit privateKey over env var', async () => {
@@ -421,7 +421,7 @@ describe('wallet signature auth', () => {
     const client = new MemoClawClient({ privateKey: TEST_PRIVATE_KEY, wallet: '0xIgnored', fetch: f });
     await client.store({ content: 'test' });
     const [, init] = f.mock.calls[0]!;
-    const walletHeader = init.headers['X-Wallet'] as string;
+    const walletHeader = init.headers['x-wallet-auth'] as string;
     // When privateKey is explicit, it should use signed auth even if wallet is also provided
     expect(walletHeader).toContain(TEST_ADDRESS);
   });


### PR DESCRIPTION
## Summary

The TypeScript SDK was sending `X-Wallet` as the authentication header, while the API server expects `x-wallet-auth` (as documented at docs.memoclaw.com and used by the Python SDK). This mismatch would cause auth failures for TS SDK users.

### Changes
- `typescript/src/client.ts`: Changed header from `X-Wallet` to `x-wallet-auth`
- `typescript/src/types.ts`: Updated JSDoc comments to reflect correct header name
- `typescript/tests/client.test.ts`: Updated test assertions

Fixes MEM-173