### PR TITLE
chore: add typescript/dist/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,10 @@ Thumbs.db
 # Node
 node_modules/
 
-# Distribution
+# Distribution / build output
 *.tar.gz
 node_modules/
+typescript/dist/
 
 # Environment files
 .env


### PR DESCRIPTION
Prevent accidental commits of TypeScript build artifacts by adding `typescript/dist/` to .gitignore.