### PR TITLE
feat: add OpenClaw agent integration examples

### DIFF
--- a/examples/python/openclaw_agent.py
+++ b/examples/python/openclaw_agent.py
@@ -1,0 +1,103 @@
+"""OpenClaw agent integration with MemoClaw.
+
+Shows how an OpenClaw agent can use MemoClaw as its persistent memory layer,
+replacing flat markdown files with semantic search and automatic deduplication.
+
+Usage:
+    pip install memoclaw
+    export MEMOCLAW_PRIVATE_KEY=0x...
+    python openclaw_agent.py
+"""
+
+from __future__ import annotations
+
+from memoclaw import MemoClaw
+
+
+def main() -> None:
+    client = MemoClaw()
+
+    # ── 1. Migrate existing AGENTS.md memory files ────────────────────
+    # OpenClaw agents store daily notes in memory/YYYY-MM-DD.md.
+    # Migrate them to MemoClaw for semantic search instead of flat-file reads.
+    try:
+        result = client.migrate_directory(
+            "memory/",
+            pattern="*.md",
+            namespace="daily-notes",
+            auto_tag=True,
+        )
+        print(f"Migrated {result.imported} memories from daily notes")
+    except ValueError:
+        print("No memory files to migrate (first run?)")
+
+    # ── 2. Store memories from agent interactions ─────────────────────
+    # During conversations, store important facts.
+    stored = client.store(
+        "User prefers concise responses and dislikes filler phrases like 'Great question!'",
+        importance=0.9,
+        tags=["preferences", "communication-style"],
+        namespace="user-profile",
+        pinned=True,  # Core preferences should never decay
+    )
+    print(f"Stored: {stored.id}")
+
+    # ── 3. Recall context before responding ───────────────────────────
+    # Before generating a response, recall relevant memories.
+    memories = client.recall(
+        "What does the user prefer about communication style?",
+        namespace="user-profile",
+        limit=5,
+    )
+    for m in memories.memories:
+        print(f"  [{m.similarity:.2f}] {m.content[:80]}")
+
+    # ── 4. Assemble context for LLM prompts ──────────────────────────
+    # Build a context block to inject into system prompts.
+    ctx = client.assemble_context(
+        "user preferences and recent conversations",
+        max_memories=10,
+        max_tokens=500,
+        format="markdown",
+    )
+    print(f"\nContext block ({ctx.token_estimate} tokens):\n{ctx.context[:200]}...")
+
+    # ── 5. Ingest conversations automatically ─────────────────────────
+    # After each conversation turn, extract and store facts.
+    client.ingest(
+        messages=[
+            {"role": "user", "content": "I'm working on a Rust project called memoclaw-rs"},
+            {"role": "assistant", "content": "I'll remember that. What aspect are you working on?"},
+            {"role": "user", "content": "The FFI bindings for Python"},
+        ],
+        namespace="conversations",
+        agent_id="openclaw-main",
+    )
+
+    # ── 6. Consolidate during heartbeats ──────────────────────────────
+    # Run periodically (e.g., in HEARTBEAT.md checks) to merge duplicates.
+    result = client.consolidate(namespace="conversations", dry_run=True)
+    print(f"\nConsolidation preview: {result.merged_count} memories would be merged")
+
+    # ── 7. Multi-agent namespace isolation ────────────────────────────
+    # Each OpenClaw agent/subagent can use its own namespace.
+    client.store(
+        "CI pipeline for memoclaw-sdk uses GitHub Actions with Python 3.10-3.13 matrix",
+        namespace="agent:backend",
+        agent_id="backend-subagent",
+        tags=["ci", "infrastructure"],
+    )
+
+    # ── 8. Core memories for quick access ─────────────────────────────
+    # Get the most important memories without semantic search (free tier).
+    core = client.core_memories(namespace="user-profile", limit=5)
+    print(f"\nCore memories: {len(core.memories)} found")
+    for m in core.memories:
+        print(f"  [importance={m.importance}] {m.content[:60]}")
+
+    client.close()
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/typescript/openclaw_agent.ts
+++ b/examples/typescript/openclaw_agent.ts
@@ -1,0 +1,100 @@
+/**
+ * OpenClaw agent integration with MemoClaw.
+ *
+ * Shows how an OpenClaw agent can use MemoClaw as its persistent memory layer,
+ * replacing flat markdown files with semantic search and automatic deduplication.
+ *
+ * Usage:
+ *   npm install @memoclaw/sdk
+ *   export MEMOCLAW_WALLET=0x...
+ *   npx tsx openclaw_agent.ts
+ */
+
+import { MemoClawClient } from '@memoclaw/sdk';
+
+async function main() {
+  const client = new MemoClawClient();
+
+  // ── 1. Migrate existing AGENTS.md memory files ────────────────────
+  // OpenClaw agents store daily notes in memory/YYYY-MM-DD.md.
+  // Migrate them to MemoClaw for semantic search instead of flat-file reads.
+  try {
+    const migrated = await client.migrateDirectory('./memory', {
+      namespace: 'daily-notes',
+      auto_tag: true,
+    });
+    console.log(`Migrated ${migrated.imported} memories from daily notes`);
+  } catch {
+    console.log('No memory files to migrate (first run?)');
+  }
+
+  // ── 2. Store memories from agent interactions ─────────────────────
+  // During conversations, store important facts.
+  const stored = await client.store({
+    content: "User prefers concise responses and dislikes filler phrases like 'Great question!'",
+    importance: 0.9,
+    metadata: { tags: ['preferences', 'communication-style'] },
+    namespace: 'user-profile',
+    pinned: true, // Core preferences should never decay
+  });
+  console.log(`Stored: ${stored.id}`);
+
+  // ── 3. Recall context before responding ───────────────────────────
+  // Before generating a response, recall relevant memories.
+  const memories = await client.recall({
+    query: 'What does the user prefer about communication style?',
+    namespace: 'user-profile',
+    limit: 5,
+  });
+  for (const m of memories.memories) {
+    console.log(`  [${m.similarity.toFixed(2)}] ${m.content.slice(0, 80)}`);
+  }
+
+  // ── 4. Assemble context for LLM prompts ──────────────────────────
+  // Build a context block to inject into system prompts.
+  const ctx = await client.assembleContext({
+    query: 'user preferences and recent conversations',
+    max_memories: 10,
+    max_tokens: 500,
+    format: 'markdown',
+  });
+  console.log(`\nContext block (${ctx.token_estimate} tokens):\n${ctx.context.slice(0, 200)}...`);
+
+  // ── 5. Ingest conversations automatically ─────────────────────────
+  // After each conversation turn, extract and store facts.
+  await client.ingest({
+    messages: [
+      { role: 'user', content: "I'm working on a Rust project called memoclaw-rs" },
+      { role: 'assistant', content: "I'll remember that. What aspect are you working on?" },
+      { role: 'user', content: 'The FFI bindings for Python' },
+    ],
+    namespace: 'conversations',
+    agent_id: 'openclaw-main',
+  });
+
+  // ── 6. Consolidate during heartbeats ──────────────────────────────
+  // Run periodically (e.g., in HEARTBEAT.md checks) to merge duplicates.
+  const consolidated = await client.consolidate({ dry_run: true, namespace: 'conversations' });
+  console.log(`\nConsolidation preview: ${consolidated.merged_count} memories would be merged`);
+
+  // ── 7. Multi-agent namespace isolation ────────────────────────────
+  // Each OpenClaw agent/subagent can use its own namespace.
+  await client.store({
+    content: 'CI pipeline for memoclaw-sdk uses GitHub Actions with Python 3.10-3.13 matrix',
+    namespace: 'agent:backend',
+    agent_id: 'backend-subagent',
+    metadata: { tags: ['ci', 'infrastructure'] },
+  });
+
+  // ── 8. Core memories for quick access ─────────────────────────────
+  // Get the most important memories without semantic search (free tier).
+  const core = await client.coreMemories({ namespace: 'user-profile', limit: 5 });
+  console.log(`\nCore memories: ${core.memories.length} found`);
+  for (const m of core.memories) {
+    console.log(`  [importance=${m.importance}] ${m.content.slice(0, 60)}`);
+  }
+
+  console.log('\nDone!');
+}
+
+main().catch(console.error);

--- a/python/README.md
+++ b/python/README.md
@@ -129,6 +129,30 @@ client = MemoClaw(
 )
 ```
 
+## OpenClaw Integration
+
+MemoClaw is the recommended memory layer for [OpenClaw](https://openclaw.com) agents. Replace flat `memory/*.md` files with semantic search:
+
+```python
+from memoclaw import MemoClaw
+
+client = MemoClaw()
+
+# Migrate existing daily notes
+client.migrate_directory("memory/", namespace="daily-notes", auto_tag=True)
+
+# Store facts during conversations
+client.store("User prefers dark mode", importance=0.9, namespace="user-profile", pinned=True)
+
+# Recall context before responding
+memories = client.recall("user preferences", namespace="user-profile", limit=5)
+
+# Consolidate during heartbeats
+client.consolidate(namespace="conversations")
+```
+
+See [`examples/python/openclaw_agent.py`](../examples/python/openclaw_agent.py) for a complete integration guide.
+
 ## License
 
 MIT

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -107,6 +107,30 @@ try {
 }
 ```
 
+## OpenClaw Integration
+
+MemoClaw is the recommended memory layer for [OpenClaw](https://openclaw.com) agents. Replace flat `memory/*.md` files with semantic search:
+
+```ts
+import { MemoClawClient } from '@memoclaw/sdk';
+
+const client = new MemoClawClient();
+
+// Migrate existing daily notes
+await client.migrateDirectory('./memory', { namespace: 'daily-notes', auto_tag: true });
+
+// Store facts during conversations
+await client.store({ content: 'User prefers dark mode', importance: 0.9, namespace: 'user-profile', pinned: true });
+
+// Recall context before responding
+const memories = await client.recall({ query: 'user preferences', namespace: 'user-profile', limit: 5 });
+
+// Consolidate during heartbeats
+await client.consolidate({ namespace: 'conversations' });
+```
+
+See [`examples/typescript/openclaw_agent.ts`](../examples/typescript/openclaw_agent.ts) for a complete integration guide.
+
 ## License
 
 MIT


### PR DESCRIPTION
## What

Adds OpenClaw-specific integration examples and README sections for both Python and TypeScript SDKs.

### Changes
- **`examples/python/openclaw_agent.py`** — Complete Python example showing MemoClaw as an OpenClaw agent's memory layer
- **`examples/typescript/openclaw_agent.ts`** — Same patterns for TypeScript agents
- **Python & TypeScript READMEs** — Added "OpenClaw Integration" sections with quick-start code

### Patterns demonstrated
1. Migrating existing `memory/*.md` files to MemoClaw via `migrate_directory`
2. Storing facts with importance scoring and pinning
3. Semantic recall for context assembly before LLM responses
4. `assemble_context` for injecting memory into system prompts
5. Auto-ingesting conversations with `ingest`
6. Periodic consolidation (ideal for heartbeat checks)
7. Multi-agent namespace isolation (`agent:backend`, `agent:main`, etc.)
8. Core memories for free-tier quick access

### Why
OpenClaw users are our primary target audience. All existing examples showed generic AI assistant patterns. This makes the OpenClaw integration path explicit and easy to follow.