### PR TITLE
fix: correct repository and documentation URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "memoclaw-sdk",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,8 +41,8 @@ dev = [
 
 [project.urls]
 Homepage = "https://memoclaw.com"
-Documentation = "https://memoclaw.com/docs"
-Repository = "https://github.com/memoclaw/memoclaw-sdk"
+Documentation = "https://docs.memoclaw.com"
+Repository = "https://github.com/anajuliabit/memoclaw-sdk"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/memoclaw"]

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -33,7 +33,7 @@
   "author": "MemoClaw",
   "repository": {
     "type": "git",
-    "url": "https://github.com/memoclaw/memoclaw-sdk",
+    "url": "https://github.com/anajuliabit/memoclaw-sdk",
     "directory": "typescript"
   },
   "peerDependencies": {


### PR DESCRIPTION
Fixes incorrect URLs in package metadata:

- **typescript/package.json**: `memoclaw/memoclaw-sdk` → `anajuliabit/memoclaw-sdk`
- **python/pyproject.toml**: `memoclaw/memoclaw-sdk` → `anajuliabit/memoclaw-sdk`
- **python/pyproject.toml**: `memoclaw.com/docs` → `docs.memoclaw.com`

These URLs are used by npm/PyPI to link back to the source repo and docs.