### PR TITLE
fix(python): add missing status codes to error map and retry set

### DIFF
--- a/python/src/memoclaw/_client.py
+++ b/python/src/memoclaw/_client.py
@@ -20,7 +20,7 @@ DEFAULT_POOL_MAX_CONNECTIONS = 10
 DEFAULT_POOL_MAX_KEEPALIVE_CONNECTIONS = 5
 
 # Status codes that are safe to retry (transient server errors)
-_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+_RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
 
 # Base delay between retries in seconds (exponential backoff: base * 2^attempt)
 _RETRY_BASE_DELAY = 0.5

--- a/python/src/memoclaw/errors.py
+++ b/python/src/memoclaw/errors.py
@@ -154,4 +154,7 @@ _STATUS_MAP: dict[int, type[APIError]] = {
     422: ValidationError,
     429: RateLimitError,
     500: InternalServerError,
+    502: InternalServerError,
+    503: InternalServerError,
+    504: InternalServerError,
 }


### PR DESCRIPTION
## Changes

- **`_STATUS_MAP`**: Added 502, 503, 504 → `InternalServerError` (previously fell back to base `APIError`)
- **`_RETRYABLE_STATUS_CODES`**: Added 408 (Request Timeout) for parity with TS SDK

## Why

Without these mappings:
- 502/503/504 errors raise `APIError` instead of `InternalServerError`, breaking `except InternalServerError` catch blocks
- 408 Request Timeout responses aren't retried, causing unnecessary failures

All 192 Python tests pass.