### PR TITLE
feat: per-request timeout on all SDK methods (TS + Python)

### DIFF
--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -295,8 +295,14 @@ class MemoClaw:
     def store_batch(
         self,
         memories: list[StoreInput | dict[str, Any]],
+        *,
+        timeout: float | None = None,
     ) -> StoreBatchResult:
-        """Store up to 100 memories at once."""
+        """Store up to 100 memories at once.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         if not memories:
             raise ValueError("memories list must not be empty")
         if len(memories) > MAX_BATCH_SIZE:
@@ -307,7 +313,7 @@ class MemoClaw:
             m.model_dump(exclude_none=True) if isinstance(m, StoreInput) else m
             for m in memories
         ]
-        data = self._run_request("POST", "/v1/store/batch", json={"memories": items})
+        data = self._run_request("POST", "/v1/store/batch", json={"memories": items}, timeout=timeout)
         return StoreBatchResult.model_validate(data)
 
     def store_builder(self) -> StoreBuilder:
@@ -444,8 +450,13 @@ class MemoClaw:
         pinned: bool | None = None,
         immutable: bool | None = None,
         expires_at: str | None = ...,  # type: ignore[assignment]
+        timeout: float | None = None,
     ) -> Memory:
-        """Update a memory by ID. Only provided fields are updated."""
+        """Update a memory by ID. Only provided fields are updated.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         body: dict[str, Any] = {}
         if content is not None:
             body["content"] = content
@@ -465,7 +476,7 @@ class MemoClaw:
         if expires_at is not ...:
             body["expires_at"] = expires_at
 
-        data = self._run_request("PATCH", f"/v1/memories/{quote(memory_id, safe='')}", json=body)
+        data = self._run_request("PATCH", f"/v1/memories/{quote(memory_id, safe='')}", json=body, timeout=timeout)
         return Memory.model_validate(data)
 
     # ── Batch Update ─────────────────────────────────────────────────────
@@ -473,6 +484,8 @@ class MemoClaw:
     def update_batch(
         self,
         updates: list[UpdateInput | dict[str, Any]],
+        *,
+        timeout: float | None = None,
     ) -> UpdateBatchResult:
         """Update multiple memories in a single request.
 
@@ -502,7 +515,7 @@ class MemoClaw:
             if "id" not in item or not item["id"]:
                 raise ValueError("Each update must include a non-empty 'id'")
         data = self._run_request(
-            "POST", "/v1/memories/batch-update", json={"updates": items}
+            "POST", "/v1/memories/batch-update", json={"updates": items}, timeout=timeout
         )
         return UpdateBatchResult.model_validate(data)
 
@@ -514,7 +527,7 @@ class MemoClaw:
         data = self._run_request("DELETE", f"/v1/memories/{quote(memory_id, safe='')}", timeout=timeout)
         return DeleteResult.model_validate(data)
 
-    def delete_batch(self, memory_ids: list[str]) -> list[DeleteResult]:
+    def delete_batch(self, memory_ids: list[str], *, timeout: float | None = None) -> list[DeleteResult]:
         """Delete multiple memories by ID using the batch endpoint.
 
         Processes in chunks of 50 for API compatibility.
@@ -526,7 +539,7 @@ class MemoClaw:
         for i in range(0, len(memory_ids), 50):
             chunk = memory_ids[i : i + 50]
             data = self._run_request(
-                "POST", "/v1/memories/batch-delete", json={"ids": chunk}
+                "POST", "/v1/memories/batch-delete", json={"ids": chunk}, timeout=timeout
             )
             for item in data.get("results", []):
                 results.append(DeleteResult.model_validate(item))
@@ -546,8 +559,13 @@ class MemoClaw:
         session_id: str | None = None,
         agent_id: str | None = None,
         auto_relate: bool | None = None,
+        timeout: float | None = None,
     ) -> IngestResult:
-        """Auto-extract and store facts from conversation or text."""
+        """Auto-extract and store facts from conversation or text.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         body: dict[str, Any] = {}
         if messages is not None:
             body["messages"] = [
@@ -564,7 +582,7 @@ class MemoClaw:
         if auto_relate is not None:
             body["auto_relate"] = auto_relate
 
-        data = self._run_request("POST", "/v1/ingest", json=body)
+        data = self._run_request("POST", "/v1/ingest", json=body, timeout=timeout)
         return IngestResult.model_validate(data)
 
     # ── Extract ──────────────────────────────────────────────────────────
@@ -576,8 +594,13 @@ class MemoClaw:
         namespace: str | None = None,
         session_id: str | None = None,
         agent_id: str | None = None,
+        timeout: float | None = None,
     ) -> ExtractResult:
-        """Extract structured facts from conversation via LLM."""
+        """Extract structured facts from conversation via LLM.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         body: dict[str, Any] = {
             "messages": [
                 m.model_dump() if isinstance(m, Message) else m for m in messages
@@ -590,7 +613,7 @@ class MemoClaw:
         if agent_id is not None:
             body["agent_id"] = agent_id
 
-        data = self._run_request("POST", "/v1/memories/extract", json=body)
+        data = self._run_request("POST", "/v1/memories/extract", json=body, timeout=timeout)
         return ExtractResult.model_validate(data)
 
     # ── Consolidate ──────────────────────────────────────────────────────
@@ -602,8 +625,13 @@ class MemoClaw:
         min_similarity: float | None = None,
         mode: str | None = None,
         dry_run: bool | None = None,
+        timeout: float | None = None,
     ) -> ConsolidateResult:
-        """Merge similar memories by clustering."""
+        """Merge similar memories by clustering.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         body = _clean_body(
             {
                 "namespace": namespace,
@@ -612,7 +640,7 @@ class MemoClaw:
                 "dry_run": dry_run,
             }
         )
-        data = self._run_request("POST", "/v1/memories/consolidate", json=body)
+        data = self._run_request("POST", "/v1/memories/consolidate", json=body, timeout=timeout)
         return ConsolidateResult.model_validate(data)
 
     # ── Suggested ────────────────────────────────────────────────────────
@@ -625,8 +653,13 @@ class MemoClaw:
         session_id: str | None = None,
         agent_id: str | None = None,
         category: SuggestedCategory | None = None,
+        timeout: float | None = None,
     ) -> SuggestedResponse:
-        """Get proactive memory suggestions."""
+        """Get proactive memory suggestions.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         params = _clean_params(
             {
                 "limit": limit,
@@ -636,7 +669,7 @@ class MemoClaw:
                 "category": category,
             }
         )
-        data = self._run_request("GET", "/v1/suggested", params=params)
+        data = self._run_request("GET", "/v1/suggested", params=params, timeout=timeout)
         return SuggestedResponse.model_validate(data)
 
     # ── Relations ────────────────────────────────────────────────────────
@@ -648,8 +681,13 @@ class MemoClaw:
         relation_type: RelationType,
         *,
         metadata: dict[str, Any] | None = None,
+        timeout: float | None = None,
     ) -> Relation:
-        """Create a relationship between two memories."""
+        """Create a relationship between two memories.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         _validate_non_empty(memory_id, "memory_id")
         _validate_non_empty(target_id, "target_id")
         body: dict[str, Any] = {
@@ -659,31 +697,43 @@ class MemoClaw:
         if metadata is not None:
             body["metadata"] = metadata
         data = self._run_request(
-            "POST", f"/v1/memories/{quote(memory_id, safe='')}/relations", json=body
+            "POST", f"/v1/memories/{quote(memory_id, safe='')}/relations", json=body, timeout=timeout
         )
         return Relation.model_validate(data)
 
-    def list_relations(self, memory_id: str) -> list[RelationWithMemory]:
-        """List all relationships for a memory."""
+    def list_relations(self, memory_id: str, *, timeout: float | None = None) -> list[RelationWithMemory]:
+        """List all relationships for a memory.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         _validate_non_empty(memory_id, "memory_id")
-        data = self._run_request("GET", f"/v1/memories/{quote(memory_id, safe='')}/relations")
+        data = self._run_request("GET", f"/v1/memories/{quote(memory_id, safe='')}/relations", timeout=timeout)
         resp = RelationsResponse.model_validate(data)
         return resp.relations  # type: ignore[return-value]
 
-    def delete_relation(self, memory_id: str, relation_id: str) -> DeleteResult:
-        """Delete a memory relationship."""
+    def delete_relation(self, memory_id: str, relation_id: str, *, timeout: float | None = None) -> DeleteResult:
+        """Delete a memory relationship.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         _validate_non_empty(memory_id, "memory_id")
         _validate_non_empty(relation_id, "relation_id")
         data = self._run_request(
-            "DELETE", f"/v1/memories/{quote(memory_id, safe='')}/relations/{quote(relation_id, safe='')}"
+            "DELETE", f"/v1/memories/{quote(memory_id, safe='')}/relations/{quote(relation_id, safe='')}", timeout=timeout
         )
         return DeleteResult.model_validate(data)
 
     # ── Status ───────────────────────────────────────────────────────────
 
-    def status(self) -> FreeTierStatus:
-        """Check free tier remaining calls."""
-        data = self._run_request("GET", "/v1/free-tier/status")
+    def status(self, *, timeout: float | None = None) -> FreeTierStatus:
+        """Check free tier remaining calls.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
+        data = self._run_request("GET", "/v1/free-tier/status", timeout=timeout)
         return FreeTierStatus.model_validate(data)
 
     # ── Migrate ───────────────────────────────────────────────────────────
@@ -696,6 +746,7 @@ class MemoClaw:
         agent_id: str | None = None,
         session_id: str | None = None,
         auto_tag: bool | None = None,
+        timeout: float | None = None,
     ) -> MigrateResult:
         """Bulk import markdown memory files.
 
@@ -727,7 +778,7 @@ class MemoClaw:
             body["session_id"] = session_id
         if auto_tag is not None:
             body["auto_tag"] = auto_tag
-        data = self._run_request("POST", "/v1/migrate", json=body)
+        data = self._run_request("POST", "/v1/migrate", json=body, timeout=timeout)
         return MigrateResult.model_validate(data)
 
     def migrate_directory(
@@ -739,6 +790,7 @@ class MemoClaw:
         agent_id: str | None = None,
         session_id: str | None = None,
         auto_tag: bool | None = None,
+        timeout: float | None = None,
     ) -> MigrateResult:
         """Convenience: migrate all matching files from a directory.
 
@@ -762,6 +814,7 @@ class MemoClaw:
             agent_id=agent_id,
             session_id=session_id,
             auto_tag=auto_tag,
+            timeout=timeout,
         )
 
     # ── Context ───────────────────────────────────────────────────────────
@@ -778,8 +831,13 @@ class MemoClaw:
         format: str | None = None,
         include_metadata: bool | None = None,
         summarize: bool | None = None,
+        timeout: float | None = None,
     ) -> ContextResult:
-        """Assemble a context block from memories for LLM prompts."""
+        """Assemble a context block from memories for LLM prompts.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         _validate_non_empty(query, "query")
         body = _clean_body(
             {
@@ -794,21 +852,29 @@ class MemoClaw:
                 "summarize": summarize,
             }
         )
-        data = self._run_request("POST", "/v1/context", json=body)
+        data = self._run_request("POST", "/v1/context", json=body, timeout=timeout)
         return ContextResult.model_validate(data)
 
     # ── Namespaces ───────────────────────────────────────────────────────
 
-    def list_namespaces(self) -> NamespacesResponse:
-        """List all namespaces with memory counts."""
-        data = self._run_request("GET", "/v1/namespaces")
+    def list_namespaces(self, *, timeout: float | None = None) -> NamespacesResponse:
+        """List all namespaces with memory counts.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
+        data = self._run_request("GET", "/v1/namespaces", timeout=timeout)
         return NamespacesResponse.model_validate(data)
 
     # ── Stats ────────────────────────────────────────────────────────────
 
-    def stats(self) -> StatsResponse:
-        """Get memory usage statistics."""
-        data = self._run_request("GET", "/v1/stats")
+    def stats(self, *, timeout: float | None = None) -> StatsResponse:
+        """Get memory usage statistics.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
+        data = self._run_request("GET", "/v1/stats", timeout=timeout)
         return StatsResponse.model_validate(data)
 
     # ── Core Memories ────────────────────────────────────────────────────
@@ -819,12 +885,17 @@ class MemoClaw:
         limit: int | None = None,
         namespace: str | None = None,
         agent_id: str | None = None,
+        timeout: float | None = None,
     ) -> CoreMemoriesResponse:
-        """Get high-importance, pinned, and frequently-accessed memories (FREE)."""
+        """Get high-importance, pinned, and frequently-accessed memories (FREE).
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         params = _clean_params(
             {"limit": limit, "namespace": namespace, "agent_id": agent_id}
         )
-        data = self._run_request("GET", "/v1/core-memories", params=params)
+        data = self._run_request("GET", "/v1/core-memories", params=params, timeout=timeout)
         return CoreMemoriesResponse.model_validate(data)
 
     # ── Text Search ──────────────────────────────────────────────────────
@@ -840,8 +911,13 @@ class MemoClaw:
         session_id: str | None = None,
         agent_id: str | None = None,
         after: str | None = None,
+        timeout: float | None = None,
     ) -> TextSearchResponse:
-        """Keyword text search across memories (FREE)."""
+        """Keyword text search across memories (FREE).
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         _validate_non_empty(query, "query")
         params = _clean_params(
             {
@@ -855,7 +931,7 @@ class MemoClaw:
                 "after": after,
             }
         )
-        data = self._run_request("GET", "/v1/memories/search", params=params)
+        data = self._run_request("GET", "/v1/memories/search", params=params, timeout=timeout)
         return TextSearchResponse.model_validate(data)
 
     # ── Export ────────────────────────────────────────────────────────────
@@ -872,8 +948,13 @@ class MemoClaw:
         before: str | None = None,
         after: str | None = None,
         include_deleted: bool | None = None,
+        timeout: float | None = None,
     ) -> ExportResponse:
-        """Export memories in JSON, CSV, or Markdown format."""
+        """Export memories in JSON, CSV, or Markdown format.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         params = _clean_params(
             {
                 "format": format,
@@ -887,15 +968,19 @@ class MemoClaw:
                 "include_deleted": include_deleted,
             }
         )
-        data = self._run_request("GET", "/v1/export", params=params)
+        data = self._run_request("GET", "/v1/export", params=params, timeout=timeout)
         return ExportResponse.model_validate(data)
 
     # ── History ──────────────────────────────────────────────────────────
 
-    def get_history(self, memory_id: str) -> list[HistoryEntry]:
-        """Get the change history for a memory."""
+    def get_history(self, memory_id: str, *, timeout: float | None = None) -> list[HistoryEntry]:
+        """Get the change history for a memory.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         _validate_non_empty(memory_id, "memory_id")
-        data = self._run_request("GET", f"/v1/memories/{quote(memory_id, safe='')}/history")
+        data = self._run_request("GET", f"/v1/memories/{quote(memory_id, safe='')}/history", timeout=timeout)
         resp = HistoryResponse.model_validate(data)
         return resp.history
 
@@ -1142,8 +1227,14 @@ class AsyncMemoClaw:
     async def store_batch(
         self,
         memories: list[StoreInput | dict[str, Any]],
+        *,
+        timeout: float | None = None,
     ) -> StoreBatchResult:
-        """Store up to 100 memories at once."""
+        """Store up to 100 memories at once.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         if not memories:
             raise ValueError("memories list must not be empty")
         if len(memories) > MAX_BATCH_SIZE:
@@ -1155,7 +1246,7 @@ class AsyncMemoClaw:
             for m in memories
         ]
         data = await self._run_request(
-            "POST", "/v1/store/batch", json={"memories": items}
+            "POST", "/v1/store/batch", json={"memories": items}, timeout=timeout
         )
         return StoreBatchResult.model_validate(data)
 
@@ -1294,8 +1385,13 @@ class AsyncMemoClaw:
         pinned: bool | None = None,
         immutable: bool | None = None,
         expires_at: str | None = ...,  # type: ignore[assignment]
+        timeout: float | None = None,
     ) -> Memory:
-        """Update a memory by ID. Only provided fields are updated."""
+        """Update a memory by ID. Only provided fields are updated.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         body: dict[str, Any] = {}
         if content is not None:
             body["content"] = content
@@ -1315,7 +1411,7 @@ class AsyncMemoClaw:
             body["expires_at"] = expires_at
 
         data = await self._run_request(
-            "PATCH", f"/v1/memories/{quote(memory_id, safe='')}", json=body
+            "PATCH", f"/v1/memories/{quote(memory_id, safe='')}", json=body, timeout=timeout
         )
         return Memory.model_validate(data)
 
@@ -1324,6 +1420,8 @@ class AsyncMemoClaw:
     async def update_batch(
         self,
         updates: list[UpdateInput | dict[str, Any]],
+        *,
+        timeout: float | None = None,
     ) -> UpdateBatchResult:
         """Update multiple memories in a single request.
 
@@ -1353,7 +1451,7 @@ class AsyncMemoClaw:
             if "id" not in item or not item["id"]:
                 raise ValueError("Each update must include a non-empty 'id'")
         data = await self._run_request(
-            "POST", "/v1/memories/batch-update", json={"updates": items}
+            "POST", "/v1/memories/batch-update", json={"updates": items}, timeout=timeout
         )
         return UpdateBatchResult.model_validate(data)
 
@@ -1365,7 +1463,7 @@ class AsyncMemoClaw:
         data = await self._run_request("DELETE", f"/v1/memories/{quote(memory_id, safe='')}", timeout=timeout)
         return DeleteResult.model_validate(data)
 
-    async def delete_batch(self, memory_ids: list[str]) -> list[DeleteResult]:
+    async def delete_batch(self, memory_ids: list[str], *, timeout: float | None = None) -> list[DeleteResult]:
         """Delete multiple memories by ID using the batch endpoint.
 
         Processes in chunks of 50 for API compatibility.
@@ -1377,7 +1475,7 @@ class AsyncMemoClaw:
         for i in range(0, len(memory_ids), 50):
             chunk = memory_ids[i : i + 50]
             data = await self._run_request(
-                "POST", "/v1/memories/batch-delete", json={"ids": chunk}
+                "POST", "/v1/memories/batch-delete", json={"ids": chunk}, timeout=timeout
             )
             for item in data.get("results", []):
                 results.append(DeleteResult.model_validate(item))
@@ -1397,8 +1495,13 @@ class AsyncMemoClaw:
         session_id: str | None = None,
         agent_id: str | None = None,
         auto_relate: bool | None = None,
+        timeout: float | None = None,
     ) -> IngestResult:
-        """Auto-extract and store facts from conversation or text."""
+        """Auto-extract and store facts from conversation or text.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         body: dict[str, Any] = {}
         if messages is not None:
             body["messages"] = [
@@ -1415,7 +1518,7 @@ class AsyncMemoClaw:
         if auto_relate is not None:
             body["auto_relate"] = auto_relate
 
-        data = await self._run_request("POST", "/v1/ingest", json=body)
+        data = await self._run_request("POST", "/v1/ingest", json=body, timeout=timeout)
         return IngestResult.model_validate(data)
 
     # ── Extract ──────────────────────────────────────────────────────────
@@ -1427,8 +1530,13 @@ class AsyncMemoClaw:
         namespace: str | None = None,
         session_id: str | None = None,
         agent_id: str | None = None,
+        timeout: float | None = None,
     ) -> ExtractResult:
-        """Extract structured facts from conversation via LLM."""
+        """Extract structured facts from conversation via LLM.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         body: dict[str, Any] = {
             "messages": [
                 m.model_dump() if isinstance(m, Message) else m for m in messages
@@ -1441,7 +1549,7 @@ class AsyncMemoClaw:
         if agent_id is not None:
             body["agent_id"] = agent_id
 
-        data = await self._run_request("POST", "/v1/memories/extract", json=body)
+        data = await self._run_request("POST", "/v1/memories/extract", json=body, timeout=timeout)
         return ExtractResult.model_validate(data)
 
     # ── Consolidate ──────────────────────────────────────────────────────
@@ -1453,8 +1561,13 @@ class AsyncMemoClaw:
         min_similarity: float | None = None,
         mode: str | None = None,
         dry_run: bool | None = None,
+        timeout: float | None = None,
     ) -> ConsolidateResult:
-        """Merge similar memories by clustering."""
+        """Merge similar memories by clustering.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         body = _clean_body(
             {
                 "namespace": namespace,
@@ -1464,7 +1577,7 @@ class AsyncMemoClaw:
             }
         )
         data = await self._run_request(
-            "POST", "/v1/memories/consolidate", json=body
+            "POST", "/v1/memories/consolidate", json=body, timeout=timeout
         )
         return ConsolidateResult.model_validate(data)
 
@@ -1478,8 +1591,13 @@ class AsyncMemoClaw:
         session_id: str | None = None,
         agent_id: str | None = None,
         category: SuggestedCategory | None = None,
+        timeout: float | None = None,
     ) -> SuggestedResponse:
-        """Get proactive memory suggestions."""
+        """Get proactive memory suggestions.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         params = _clean_params(
             {
                 "limit": limit,
@@ -1489,7 +1607,7 @@ class AsyncMemoClaw:
                 "category": category,
             }
         )
-        data = await self._run_request("GET", "/v1/suggested", params=params)
+        data = await self._run_request("GET", "/v1/suggested", params=params, timeout=timeout)
         return SuggestedResponse.model_validate(data)
 
     # ── Relations ────────────────────────────────────────────────────────
@@ -1501,8 +1619,13 @@ class AsyncMemoClaw:
         relation_type: RelationType,
         *,
         metadata: dict[str, Any] | None = None,
+        timeout: float | None = None,
     ) -> Relation:
-        """Create a relationship between two memories."""
+        """Create a relationship between two memories.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         _validate_non_empty(memory_id, "memory_id")
         _validate_non_empty(target_id, "target_id")
         body: dict[str, Any] = {
@@ -1512,35 +1635,39 @@ class AsyncMemoClaw:
         if metadata is not None:
             body["metadata"] = metadata
         data = await self._run_request(
-            "POST", f"/v1/memories/{quote(memory_id, safe='')}/relations", json=body
+            "POST", f"/v1/memories/{quote(memory_id, safe='')}/relations", json=body, timeout=timeout
         )
         return Relation.model_validate(data)
 
-    async def list_relations(self, memory_id: str) -> list[RelationWithMemory]:
+    async def list_relations(self, memory_id: str, *, timeout: float | None = None) -> list[RelationWithMemory]:
         """List all relationships for a memory."""
         _validate_non_empty(memory_id, "memory_id")
         data = await self._run_request(
-            "GET", f"/v1/memories/{quote(memory_id, safe='')}/relations"
+            "GET", f"/v1/memories/{quote(memory_id, safe='')}/relations", timeout=timeout
         )
         resp = RelationsResponse.model_validate(data)
         return resp.relations  # type: ignore[return-value]
 
     async def delete_relation(
-        self, memory_id: str, relation_id: str
+        self, memory_id: str, relation_id: str, *, timeout: float | None = None
     ) -> DeleteResult:
         """Delete a memory relationship."""
         _validate_non_empty(memory_id, "memory_id")
         _validate_non_empty(relation_id, "relation_id")
         data = await self._run_request(
-            "DELETE", f"/v1/memories/{quote(memory_id, safe='')}/relations/{quote(relation_id, safe='')}"
+            "DELETE", f"/v1/memories/{quote(memory_id, safe='')}/relations/{quote(relation_id, safe='')}", timeout=timeout
         )
         return DeleteResult.model_validate(data)
 
     # ── Status ───────────────────────────────────────────────────────────
 
-    async def status(self) -> FreeTierStatus:
-        """Check free tier remaining calls."""
-        data = await self._run_request("GET", "/v1/free-tier/status")
+    async def status(self, *, timeout: float | None = None) -> FreeTierStatus:
+        """Check free tier remaining calls.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
+        data = await self._run_request("GET", "/v1/free-tier/status", timeout=timeout)
         return FreeTierStatus.model_validate(data)
 
     # ── Migrate ───────────────────────────────────────────────────────────
@@ -1553,6 +1680,7 @@ class AsyncMemoClaw:
         agent_id: str | None = None,
         session_id: str | None = None,
         auto_tag: bool | None = None,
+        timeout: float | None = None,
     ) -> MigrateResult:
         """Bulk import markdown memory files. See sync version for details."""
         if not files:
@@ -1566,7 +1694,7 @@ class AsyncMemoClaw:
             body["session_id"] = session_id
         if auto_tag is not None:
             body["auto_tag"] = auto_tag
-        data = await self._run_request("POST", "/v1/migrate", json=body)
+        data = await self._run_request("POST", "/v1/migrate", json=body, timeout=timeout)
         return MigrateResult.model_validate(data)
 
     async def migrate_directory(
@@ -1578,6 +1706,7 @@ class AsyncMemoClaw:
         agent_id: str | None = None,
         session_id: str | None = None,
         auto_tag: bool | None = None,
+        timeout: float | None = None,
     ) -> MigrateResult:
         """Convenience: migrate all matching files from a directory. See sync version for details."""
         import asyncio
@@ -1602,6 +1731,7 @@ class AsyncMemoClaw:
             agent_id=agent_id,
             session_id=session_id,
             auto_tag=auto_tag,
+            timeout=timeout,
         )
 
     # ── Context ───────────────────────────────────────────────────────────
@@ -1618,8 +1748,13 @@ class AsyncMemoClaw:
         format: str | None = None,
         include_metadata: bool | None = None,
         summarize: bool | None = None,
+        timeout: float | None = None,
     ) -> ContextResult:
-        """Assemble a context block from memories for LLM prompts."""
+        """Assemble a context block from memories for LLM prompts.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         _validate_non_empty(query, "query")
         body = _clean_body(
             {
@@ -1634,21 +1769,29 @@ class AsyncMemoClaw:
                 "summarize": summarize,
             }
         )
-        data = await self._run_request("POST", "/v1/context", json=body)
+        data = await self._run_request("POST", "/v1/context", json=body, timeout=timeout)
         return ContextResult.model_validate(data)
 
     # ── Namespaces ───────────────────────────────────────────────────────
 
-    async def list_namespaces(self) -> NamespacesResponse:
-        """List all namespaces with memory counts."""
-        data = await self._run_request("GET", "/v1/namespaces")
+    async def list_namespaces(self, *, timeout: float | None = None) -> NamespacesResponse:
+        """List all namespaces with memory counts.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
+        data = await self._run_request("GET", "/v1/namespaces", timeout=timeout)
         return NamespacesResponse.model_validate(data)
 
     # ── Stats ────────────────────────────────────────────────────────────
 
-    async def stats(self) -> StatsResponse:
-        """Get memory usage statistics."""
-        data = await self._run_request("GET", "/v1/stats")
+    async def stats(self, *, timeout: float | None = None) -> StatsResponse:
+        """Get memory usage statistics.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
+        data = await self._run_request("GET", "/v1/stats", timeout=timeout)
         return StatsResponse.model_validate(data)
 
     # ── Core Memories ────────────────────────────────────────────────────
@@ -1659,12 +1802,17 @@ class AsyncMemoClaw:
         limit: int | None = None,
         namespace: str | None = None,
         agent_id: str | None = None,
+        timeout: float | None = None,
     ) -> CoreMemoriesResponse:
-        """Get high-importance, pinned, and frequently-accessed memories (FREE)."""
+        """Get high-importance, pinned, and frequently-accessed memories (FREE).
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         params = _clean_params(
             {"limit": limit, "namespace": namespace, "agent_id": agent_id}
         )
-        data = await self._run_request("GET", "/v1/core-memories", params=params)
+        data = await self._run_request("GET", "/v1/core-memories", params=params, timeout=timeout)
         return CoreMemoriesResponse.model_validate(data)
 
     # ── Text Search ──────────────────────────────────────────────────────
@@ -1680,8 +1828,13 @@ class AsyncMemoClaw:
         session_id: str | None = None,
         agent_id: str | None = None,
         after: str | None = None,
+        timeout: float | None = None,
     ) -> TextSearchResponse:
-        """Keyword text search across memories (FREE)."""
+        """Keyword text search across memories (FREE).
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         _validate_non_empty(query, "query")
         params = _clean_params(
             {
@@ -1695,7 +1848,7 @@ class AsyncMemoClaw:
                 "after": after,
             }
         )
-        data = await self._run_request("GET", "/v1/memories/search", params=params)
+        data = await self._run_request("GET", "/v1/memories/search", params=params, timeout=timeout)
         return TextSearchResponse.model_validate(data)
 
     # ── Export ────────────────────────────────────────────────────────────
@@ -1712,8 +1865,13 @@ class AsyncMemoClaw:
         before: str | None = None,
         after: str | None = None,
         include_deleted: bool | None = None,
+        timeout: float | None = None,
     ) -> ExportResponse:
-        """Export memories in JSON, CSV, or Markdown format."""
+        """Export memories in JSON, CSV, or Markdown format.
+
+        Args:
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         params = _clean_params(
             {
                 "format": format,
@@ -1727,15 +1885,15 @@ class AsyncMemoClaw:
                 "include_deleted": include_deleted,
             }
         )
-        data = await self._run_request("GET", "/v1/export", params=params)
+        data = await self._run_request("GET", "/v1/export", params=params, timeout=timeout)
         return ExportResponse.model_validate(data)
 
     # ── History ──────────────────────────────────────────────────────────
 
-    async def get_history(self, memory_id: str) -> list[HistoryEntry]:
+    async def get_history(self, memory_id: str, *, timeout: float | None = None) -> list[HistoryEntry]:
         """Get the change history for a memory."""
         _validate_non_empty(memory_id, "memory_id")
-        data = await self._run_request("GET", f"/v1/memories/{quote(memory_id, safe='')}/history")
+        data = await self._run_request("GET", f"/v1/memories/{quote(memory_id, safe='')}/history", timeout=timeout)
         resp = HistoryResponse.model_validate(data)
         return resp.history
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -67,6 +67,15 @@ const MAX_BATCH_SIZE = 100;
 /** Status codes that are safe to retry (transient errors). */
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
 
+/** Options that can be passed to individual API methods. */
+export interface RequestOptions {
+  /** An AbortSignal for manual cancellation. */
+  signal?: AbortSignal;
+  /** Per-request timeout in milliseconds. Creates an AbortSignal internally.
+   *  Combined with `signal` via `AbortSignal.any` when both are provided. */
+  timeout?: number;
+}
+
 /** Hook called before each request. Can modify the body. */
 export type BeforeRequestHook = (method: string, path: string, body?: unknown) => unknown | void;
 /** Hook called after each successful response. */
@@ -166,7 +175,7 @@ export class MemoClawClient {
     path: string,
     body?: unknown,
     query?: Record<string, string>,
-    signal?: AbortSignal,
+    options?: RequestOptions,
   ): Promise<T> {
     let url = `${this.baseUrl}${path}`;
     if (query) {
@@ -193,14 +202,14 @@ export class MemoClawClient {
 
     const jsonBody = processedBody !== undefined ? JSON.stringify(processedBody) : undefined;
 
-    // Combine caller signal with client-level timeout
-    let combinedSignal = signal;
-    if (this.timeout > 0) {
-      const timeoutSignal = AbortSignal.timeout(this.timeout);
-      combinedSignal = signal
-        ? AbortSignal.any([signal, timeoutSignal])
-        : timeoutSignal;
-    }
+    // Combine caller signal/timeout with client-level timeout
+    const signals: AbortSignal[] = [];
+    if (options?.signal) signals.push(options.signal);
+    if (options?.timeout && options.timeout > 0) signals.push(AbortSignal.timeout(options.timeout));
+    if (this.timeout > 0) signals.push(AbortSignal.timeout(this.timeout));
+    const combinedSignal = signals.length > 1
+      ? AbortSignal.any(signals)
+      : signals[0] ?? undefined;
 
     let lastError: MemoClawError | undefined;
 
@@ -285,15 +294,15 @@ export class MemoClawClient {
   // ── Public API ─────────────────────────────────────
 
   /** Store a single memory. */
-  async store(request: StoreRequest, options?: { signal?: AbortSignal }): Promise<StoreResponse> {
+  async store(request: StoreRequest, options?: RequestOptions): Promise<StoreResponse> {
     if (!request.content?.trim()) {
       throw new Error('content must be a non-empty string');
     }
-    return this.request<StoreResponse>('POST', '/v1/store', request, undefined, options?.signal);
+    return this.request<StoreResponse>('POST', '/v1/store', request, undefined, options);
   }
 
   /** Store multiple memories in a single request (up to 100). */
-  async storeBatch(memories: StoreRequest[], options?: { signal?: AbortSignal }): Promise<StoreBatchResponse> {
+  async storeBatch(memories: StoreRequest[], options?: RequestOptions): Promise<StoreBatchResponse> {
     if (!memories.length) {
       throw new Error('memories array must not be empty');
     }
@@ -308,7 +317,7 @@ export class MemoClawClient {
     return this.request<StoreBatchResponse>(
       'POST', '/v1/store/batch',
       { memories } satisfies StoreBatchRequest,
-      undefined, options?.signal,
+      undefined, options,
     );
   }
 
@@ -318,15 +327,15 @@ export class MemoClawClient {
   }
 
   /** Recall memories via semantic search. */
-  async recall(request: RecallRequest, options?: { signal?: AbortSignal }): Promise<RecallResponse> {
+  async recall(request: RecallRequest, options?: RequestOptions): Promise<RecallResponse> {
     if (!request.query?.trim()) {
       throw new Error('query must be a non-empty string');
     }
-    return this.request<RecallResponse>('POST', '/v1/recall', request, undefined, options?.signal);
+    return this.request<RecallResponse>('POST', '/v1/recall', request, undefined, options);
   }
 
   /** List memories with pagination and optional filters. */
-  async list(params: ListMemoriesParams = {}, options?: { signal?: AbortSignal }): Promise<ListMemoriesResponse> {
+  async list(params: ListMemoriesParams = {}, options?: RequestOptions): Promise<ListMemoriesResponse> {
     const query: Record<string, string> = {};
     if (params.limit !== undefined) query['limit'] = String(params.limit);
     if (params.offset !== undefined) query['offset'] = String(params.offset);
@@ -334,7 +343,7 @@ export class MemoClawClient {
     if (params.namespace) query['namespace'] = params.namespace;
     if (params.session_id) query['session_id'] = params.session_id;
     if (params.agent_id) query['agent_id'] = params.agent_id;
-    return this.request<ListMemoriesResponse>('GET', '/v1/memories', undefined, query, options?.signal);
+    return this.request<ListMemoriesResponse>('GET', '/v1/memories', undefined, query, options);
   }
 
   /** Async iterator over all memories with automatic pagination. */
@@ -352,19 +361,19 @@ export class MemoClawClient {
   }
 
   /** Retrieve a single memory by ID. */
-  async get(id: string, options?: { signal?: AbortSignal }): Promise<Memory> {
+  async get(id: string, options?: RequestOptions): Promise<Memory> {
     if (!id?.trim()) throw new Error('id must be a non-empty string');
-    return this.request<Memory>('GET', `/v1/memories/${encodeURIComponent(id)}`, undefined, undefined, options?.signal);
+    return this.request<Memory>('GET', `/v1/memories/${encodeURIComponent(id)}`, undefined, undefined, options);
   }
 
   /** Update a memory by ID. */
-  async update(id: string, request: UpdateMemoryRequest, options?: { signal?: AbortSignal }): Promise<Memory> {
+  async update(id: string, request: UpdateMemoryRequest, options?: RequestOptions): Promise<Memory> {
     if (!id?.trim()) throw new Error('id must be a non-empty string');
-    return this.request<Memory>('PATCH', `/v1/memories/${encodeURIComponent(id)}`, request, undefined, options?.signal);
+    return this.request<Memory>('PATCH', `/v1/memories/${encodeURIComponent(id)}`, request, undefined, options);
   }
 
   /** Update multiple memories in a single request (up to 100). */
-  async updateBatch(updates: UpdateBatchItem[], options?: { signal?: AbortSignal }): Promise<UpdateBatchResponse> {
+  async updateBatch(updates: UpdateBatchItem[], options?: RequestOptions): Promise<UpdateBatchResponse> {
     if (!updates.length) {
       throw new Error('updates array must not be empty');
     }
@@ -379,18 +388,18 @@ export class MemoClawClient {
     return this.request<UpdateBatchResponse>(
       'POST', '/v1/memories/batch-update',
       { updates } satisfies UpdateBatchRequest,
-      undefined, options?.signal,
+      undefined, options,
     );
   }
 
   /** Delete a memory by ID (soft delete). */
-  async delete(id: string, options?: { signal?: AbortSignal }): Promise<DeleteResponse> {
+  async delete(id: string, options?: RequestOptions): Promise<DeleteResponse> {
     if (!id?.trim()) throw new Error('id must be a non-empty string');
-    return this.request<DeleteResponse>('DELETE', `/v1/memories/${encodeURIComponent(id)}`, undefined, undefined, options?.signal);
+    return this.request<DeleteResponse>('DELETE', `/v1/memories/${encodeURIComponent(id)}`, undefined, undefined, options);
   }
 
   /** Delete multiple memories by ID in batch. */
-  async deleteBatch(ids: string[], options?: { signal?: AbortSignal }): Promise<import('./types.js').DeleteBatchResult[]> {
+  async deleteBatch(ids: string[], options?: RequestOptions): Promise<import('./types.js').DeleteBatchResult[]> {
     const results: import('./types.js').DeleteBatchResult[] = [];
     // Process in chunks of 50
     for (let i = 0; i < ids.length; i += 50) {
@@ -399,9 +408,8 @@ export class MemoClawClient {
         'POST',
         '/v1/memories/batch-delete',
         { ids: chunk },
-        undefined,
-        options?.signal,
-      );
+        undefined, options,
+    );
       results.push(...response.results);
     }
     return results;
@@ -413,69 +421,69 @@ export class MemoClawClient {
   }
 
   /** Ingest a conversation or text and auto-extract memories. */
-  async ingest(request: IngestRequest, options?: { signal?: AbortSignal }): Promise<IngestResponse> {
+  async ingest(request: IngestRequest, options?: RequestOptions): Promise<IngestResponse> {
     if (!request.messages?.length && !request.text?.trim()) {
       throw new Error('Either messages or text must be provided');
     }
-    return this.request<IngestResponse>('POST', '/v1/ingest', request, undefined, options?.signal);
+    return this.request<IngestResponse>('POST', '/v1/ingest', request, undefined, options);
   }
 
   /** Check free tier remaining calls. */
-  async status(options?: { signal?: AbortSignal }): Promise<FreeTierStatus> {
-    return this.request<FreeTierStatus>('GET', '/v1/free-tier/status', undefined, undefined, options?.signal);
+  async status(options?: RequestOptions): Promise<FreeTierStatus> {
+    return this.request<FreeTierStatus>('GET', '/v1/free-tier/status', undefined, undefined, options);
   }
 
   /** Extract structured facts from a conversation via LLM. */
-  async extract(request: ExtractRequest, options?: { signal?: AbortSignal }): Promise<ExtractResponse> {
+  async extract(request: ExtractRequest, options?: RequestOptions): Promise<ExtractResponse> {
     if (!request.messages?.length) {
       throw new Error('messages must be a non-empty array');
     }
-    return this.request<ExtractResponse>('POST', '/v1/memories/extract', request, undefined, options?.signal);
+    return this.request<ExtractResponse>('POST', '/v1/memories/extract', request, undefined, options);
   }
 
   /** Merge similar memories by clustering. */
-  async consolidate(request: ConsolidateRequest = {}, options?: { signal?: AbortSignal }): Promise<ConsolidateResponse> {
-    return this.request<ConsolidateResponse>('POST', '/v1/memories/consolidate', request, undefined, options?.signal);
+  async consolidate(request: ConsolidateRequest = {}, options?: RequestOptions): Promise<ConsolidateResponse> {
+    return this.request<ConsolidateResponse>('POST', '/v1/memories/consolidate', request, undefined, options);
   }
 
   /** Create a relationship between two memories. */
-  async createRelation(memoryId: string, request: CreateRelationRequest, options?: { signal?: AbortSignal }): Promise<CreateRelationResponse> {
+  async createRelation(memoryId: string, request: CreateRelationRequest, options?: RequestOptions): Promise<CreateRelationResponse> {
     if (!memoryId?.trim()) throw new Error('memoryId must be a non-empty string');
     if (!request.target_id?.trim()) throw new Error('target_id must be a non-empty string');
     return this.request<CreateRelationResponse>(
       'POST', `/v1/memories/${encodeURIComponent(memoryId)}/relations`,
-      request, undefined, options?.signal,
+      request, undefined, options,
     );
   }
 
   /** List all relationships for a memory. */
-  async listRelations(memoryId: string, options?: { signal?: AbortSignal }): Promise<ListRelationsResponse> {
+  async listRelations(memoryId: string, options?: RequestOptions): Promise<ListRelationsResponse> {
     if (!memoryId?.trim()) throw new Error('memoryId must be a non-empty string');
     return this.request<ListRelationsResponse>(
       'GET', `/v1/memories/${encodeURIComponent(memoryId)}/relations`,
-      undefined, undefined, options?.signal,
+      undefined, undefined, options,
     );
   }
 
   /** Delete a relationship. */
-  async deleteRelation(memoryId: string, relationId: string, options?: { signal?: AbortSignal }): Promise<DeleteRelationResponse> {
+  async deleteRelation(memoryId: string, relationId: string, options?: RequestOptions): Promise<DeleteRelationResponse> {
     if (!memoryId?.trim()) throw new Error('memoryId must be a non-empty string');
     if (!relationId?.trim()) throw new Error('relationId must be a non-empty string');
     return this.request<DeleteRelationResponse>(
       'DELETE', `/v1/memories/${encodeURIComponent(memoryId)}/relations/${encodeURIComponent(relationId)}`,
-      undefined, undefined, options?.signal,
+      undefined, undefined, options,
     );
   }
 
   /** Get proactive memory suggestions. */
-  async suggested(params: SuggestedParams = {}, options?: { signal?: AbortSignal }): Promise<SuggestedResponse> {
+  async suggested(params: SuggestedParams = {}, options?: RequestOptions): Promise<SuggestedResponse> {
     const query: Record<string, string> = {};
     if (params.limit !== undefined) query['limit'] = String(params.limit);
     if (params.namespace) query['namespace'] = params.namespace;
     if (params.session_id) query['session_id'] = params.session_id;
     if (params.agent_id) query['agent_id'] = params.agent_id;
     if (params.category) query['category'] = params.category;
-    return this.request<SuggestedResponse>('GET', '/v1/suggested', undefined, query, options?.signal);
+    return this.request<SuggestedResponse>('GET', '/v1/suggested', undefined, query, options);
   }
 
   // ── Migrate ────────────────────────────────────────────
@@ -488,8 +496,7 @@ export class MemoClawClient {
       agent_id?: string;
       session_id?: string;
       auto_tag?: boolean;
-      signal?: AbortSignal;
-    },
+    } & RequestOptions,
   ): Promise<MigrateResponse> {
     if (!files.length) {
       throw new Error('files array must not be empty');
@@ -499,7 +506,7 @@ export class MemoClawClient {
     if (options?.agent_id !== undefined) body.agent_id = options.agent_id;
     if (options?.session_id !== undefined) body.session_id = options.session_id;
     if (options?.auto_tag !== undefined) body.auto_tag = options.auto_tag;
-    return this.request<MigrateResponse>('POST', '/v1/migrate', body, undefined, options?.signal);
+    return this.request<MigrateResponse>('POST', '/v1/migrate', body, undefined, options);
   }
 
   /**
@@ -524,8 +531,7 @@ export class MemoClawClient {
       agent_id?: string;
       session_id?: string;
       auto_tag?: boolean;
-      signal?: AbortSignal;
-    },
+    } & RequestOptions,
   ): Promise<MigrateResponse> {
     const { readdir, readFile, stat } = await import('node:fs/promises');
     const { join, basename } = await import('node:path');
@@ -567,46 +573,47 @@ export class MemoClawClient {
       session_id: options?.session_id,
       auto_tag: options?.auto_tag,
       signal: options?.signal,
+      timeout: options?.timeout,
     });
   }
 
   // ── Context ─────────────────────────────────────────────
 
   /** Assemble a context block from memories for LLM prompts. */
-  async assembleContext(request: ContextRequest, options?: { signal?: AbortSignal }): Promise<ContextResponse> {
+  async assembleContext(request: ContextRequest, options?: RequestOptions): Promise<ContextResponse> {
     if (!request.query?.trim()) throw new Error('query must be a non-empty string');
-    return this.request<ContextResponse>('POST', '/v1/context', request, undefined, options?.signal);
+    return this.request<ContextResponse>('POST', '/v1/context', request, undefined, options);
   }
 
   // ── Namespaces ─────────────────────────────────────────
 
   /** List all namespaces with memory counts. */
-  async listNamespaces(options?: { signal?: AbortSignal }): Promise<NamespacesResponse> {
-    return this.request<NamespacesResponse>('GET', '/v1/namespaces', undefined, undefined, options?.signal);
+  async listNamespaces(options?: RequestOptions): Promise<NamespacesResponse> {
+    return this.request<NamespacesResponse>('GET', '/v1/namespaces', undefined, undefined, options);
   }
 
   // ── Stats ──────────────────────────────────────────────
 
   /** Get memory usage statistics. */
-  async stats(options?: { signal?: AbortSignal }): Promise<StatsResponse> {
-    return this.request<StatsResponse>('GET', '/v1/stats', undefined, undefined, options?.signal);
+  async stats(options?: RequestOptions): Promise<StatsResponse> {
+    return this.request<StatsResponse>('GET', '/v1/stats', undefined, undefined, options);
   }
 
   // ── Core Memories ──────────────────────────────────────
 
   /** Get high-importance, pinned, and frequently-accessed memories (FREE). */
-  async coreMemories(params: CoreMemoriesParams = {}, options?: { signal?: AbortSignal }): Promise<CoreMemoriesResponse> {
+  async coreMemories(params: CoreMemoriesParams = {}, options?: RequestOptions): Promise<CoreMemoriesResponse> {
     const query: Record<string, string> = {};
     if (params.limit !== undefined) query['limit'] = String(params.limit);
     if (params.namespace) query['namespace'] = params.namespace;
     if (params.agent_id) query['agent_id'] = params.agent_id;
-    return this.request<CoreMemoriesResponse>('GET', '/v1/core-memories', undefined, Object.keys(query).length ? query : undefined, options?.signal);
+    return this.request<CoreMemoriesResponse>('GET', '/v1/core-memories', undefined, Object.keys(query).length ? query : undefined, options);
   }
 
   // ── Text Search ───────────────────────────────────────
 
   /** Keyword text search across memories (FREE). */
-  async textSearch(params: TextSearchParams, options?: { signal?: AbortSignal }): Promise<TextSearchResponse> {
+  async textSearch(params: TextSearchParams, options?: RequestOptions): Promise<TextSearchResponse> {
     if (!params.query?.trim()) {
       throw new Error('query must be a non-empty string');
     }
@@ -618,13 +625,13 @@ export class MemoClawClient {
     if (params.session_id) query['session_id'] = params.session_id;
     if (params.agent_id) query['agent_id'] = params.agent_id;
     if (params.after) query['after'] = params.after;
-    return this.request<TextSearchResponse>('GET', '/v1/memories/search', undefined, query, options?.signal);
+    return this.request<TextSearchResponse>('GET', '/v1/memories/search', undefined, query, options);
   }
 
   // ── Export ─────────────────────────────────────────────
 
   /** Export memories in JSON, CSV, or Markdown format. */
-  async export(params: ExportParams = {}, options?: { signal?: AbortSignal }): Promise<ExportResponse> {
+  async export(params: ExportParams = {}, options?: RequestOptions): Promise<ExportResponse> {
     const query: Record<string, string> = {};
     if (params.format) query['format'] = params.format;
     if (params.namespace) query['namespace'] = params.namespace;
@@ -635,17 +642,17 @@ export class MemoClawClient {
     if (params.before) query['before'] = params.before;
     if (params.after) query['after'] = params.after;
     if (params.include_deleted !== undefined) query['include_deleted'] = String(params.include_deleted);
-    return this.request<ExportResponse>('GET', '/v1/export', undefined, query, options?.signal);
+    return this.request<ExportResponse>('GET', '/v1/export', undefined, query, options);
   }
 
   // ── History ────────────────────────────────────────────
 
   /** Get the change history for a memory. */
-  async getHistory(memoryId: string, options?: { signal?: AbortSignal }): Promise<HistoryEntry[]> {
+  async getHistory(memoryId: string, options?: RequestOptions): Promise<HistoryEntry[]> {
     if (!memoryId?.trim()) throw new Error('memoryId must be a non-empty string');
     const resp = await this.request<HistoryResponse>(
       'GET', `/v1/memories/${encodeURIComponent(memoryId)}/history`,
-      undefined, undefined, options?.signal,
+      undefined, undefined, options,
     );
     return resp.history;
   }

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -13,7 +13,7 @@ export {
   RateLimitError,
   createError,
 } from './errors.js';
-export type { BeforeRequestHook, AfterResponseHook, OnErrorHook } from './client.js';
+export type { BeforeRequestHook, AfterResponseHook, OnErrorHook, RequestOptions } from './client.js';
 export {
   RecallQuery,
   AsyncRecallQuery,


### PR DESCRIPTION
## Summary

Adds per-request timeout support to **all** public methods in both TypeScript and Python SDKs, achieving full parity.

### TypeScript SDK (Fixes #64)

- New `RequestOptions` interface: `{ signal?: AbortSignal; timeout?: number }`
- All methods now accept `RequestOptions` instead of `{ signal?: AbortSignal }`
- `timeout` (in ms) creates an `AbortSignal.timeout()` internally
- When both `timeout` and `signal` are provided, combined via `AbortSignal.any`
- Also combines with client-level `timeout` option

**Before:**
```ts
await client.store({ content: 'hello' }, { signal: AbortSignal.timeout(5000) });
```

**After:**
```ts
await client.store({ content: 'hello' }, { timeout: 5000 });
// signal still works too
await client.store({ content: 'hello' }, { signal: controller.signal, timeout: 5000 });
```

### Python SDK (Fixes #76)

- Added `timeout: float | None = None` to **all** public methods that were missing it
- Both `MemoClaw` (sync) and `AsyncMemoClaw` updated
- 21 methods updated per class: store_batch, update, update_batch, delete_batch, ingest, extract, consolidate, suggested, create_relation, list_relations, delete_relation, status, migrate, migrate_directory, assemble_context, list_namespaces, stats, core_memories, text_search, export, get_history

**Usage:**
```python
# Per-request timeout (seconds)
result = client.consolidate(timeout=120)
result = await client.migrate(files, timeout=60)
```

### Tests

- ✅ All 158 TypeScript tests pass
- ✅ All 192 Python tests pass
- Backward compatible (timeout is optional everywhere)

Fixes #64
Fixes #76