### PR TITLE
feat: add request ID surfacing and debug logging to both SDKs

### DIFF
--- a/python/src/memoclaw/_client.py
+++ b/python/src/memoclaw/_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import Any
 
@@ -10,6 +11,8 @@ from eth_account import Account
 from eth_account.messages import encode_defunct
 
 from .errors import APIError, PaymentRequiredError
+
+logger = logging.getLogger("memoclaw")
 
 DEFAULT_BASE_URL = "https://api.memoclaw.com"
 DEFAULT_TIMEOUT = 30.0
@@ -47,7 +50,8 @@ def _raise_for_status(response: httpx.Response) -> None:
         body = response.json()
     except Exception:
         body = {"error": {"code": "UNKNOWN", "message": response.text}}
-    raise APIError.from_response(response.status_code, body)
+    request_id = response.headers.get("x-request-id")
+    raise APIError.from_response(response.status_code, body, request_id=request_id)
 
 
 def _is_retryable(exc: BaseException) -> bool:
@@ -121,6 +125,9 @@ class _SyncHTTPClient:
         last_exc: BaseException | None = None
         req_timeout = timeout if timeout is not None else self._timeout
 
+        logger.debug("%s %s", method, path)
+        start = time.monotonic()
+
         for attempt in range(self._max_retries + 1):
             # Generate fresh auth header each attempt (timestamp-based)
             if self._account is not None:
@@ -136,9 +143,18 @@ class _SyncHTTPClient:
             except (httpx.ConnectError, httpx.ReadTimeout, httpx.WriteTimeout) as exc:
                 last_exc = exc
                 if attempt < self._max_retries:
+                    logger.debug("Network error on %s %s, retrying (attempt %d/%d)", method, path, attempt + 1, self._max_retries)
                     time.sleep(_RETRY_BASE_DELAY * (2**attempt))
                     continue
                 raise
+
+            duration_ms = (time.monotonic() - start) * 1000
+            req_id = response.headers.get("x-request-id", "")
+            logger.debug(
+                "%s %s → %d (%dms)%s",
+                method, path, response.status_code, duration_ms,
+                f" req={req_id}" if req_id else "",
+            )
 
             # 402 → attempt x402 payment and retry once
             if response.status_code == 402:
@@ -157,6 +173,7 @@ class _SyncHTTPClient:
                     delay = float(retry_after)
                 else:
                     delay = _RETRY_BASE_DELAY * (2**attempt)
+                logger.debug("Retrying %s %s in %.1fs (attempt %d/%d)", method, path, delay, attempt + 1, self._max_retries)
                 time.sleep(delay)
                 continue
 
@@ -231,6 +248,9 @@ class _AsyncHTTPClient:
         last_exc: BaseException | None = None
         req_timeout = timeout if timeout is not None else self._timeout
 
+        logger.debug("%s %s", method, path)
+        start = time.monotonic()
+
         for attempt in range(self._max_retries + 1):
             if self._account is not None:
                 headers = {"x-wallet-auth": _generate_wallet_auth(self._account)}
@@ -245,9 +265,18 @@ class _AsyncHTTPClient:
             except (httpx.ConnectError, httpx.ReadTimeout, httpx.WriteTimeout) as exc:
                 last_exc = exc
                 if attempt < self._max_retries:
+                    logger.debug("Network error on %s %s, retrying (attempt %d/%d)", method, path, attempt + 1, self._max_retries)
                     await asyncio.sleep(_RETRY_BASE_DELAY * (2**attempt))
                     continue
                 raise
+
+            duration_ms = (time.monotonic() - start) * 1000
+            req_id = response.headers.get("x-request-id", "")
+            logger.debug(
+                "%s %s → %d (%dms)%s",
+                method, path, response.status_code, duration_ms,
+                f" req={req_id}" if req_id else "",
+            )
 
             # 402 → attempt x402 payment and retry once
             if response.status_code == 402:
@@ -266,6 +295,7 @@ class _AsyncHTTPClient:
                     delay = float(retry_after)
                 else:
                     delay = _RETRY_BASE_DELAY * (2**attempt)
+                logger.debug("Retrying %s %s in %.1fs (attempt %d/%d)", method, path, delay, attempt + 1, self._max_retries)
                 await asyncio.sleep(delay)
                 continue
 

--- a/python/src/memoclaw/errors.py
+++ b/python/src/memoclaw/errors.py
@@ -75,6 +75,7 @@ class APIError(MemoClawError):
         message: Human-readable error message.
         details: Optional structured error details.
         suggestion: Actionable suggestion for fixing the error.
+        request_id: Server-side request ID from the ``x-request-id`` header, if available.
     """
 
     status_code: int
@@ -82,6 +83,7 @@ class APIError(MemoClawError):
     message: str
     details: dict[str, Any] | None
     suggestion: str | None
+    request_id: str | None
 
     def __init__(
         self,
@@ -89,19 +91,24 @@ class APIError(MemoClawError):
         code: str,
         message: str,
         details: dict[str, Any] | None = None,
+        *,
+        request_id: str | None = None,
     ) -> None:
         self.status_code = status_code
         self.code = code
         self.message = message
         self.details = details
+        self.request_id = request_id
         self.suggestion = _get_suggestion(status_code, code)
         msg = f"[{status_code}] {code}: {message}"
+        if self.request_id:
+            msg += f"\n  request-id: {self.request_id}"
         if self.suggestion:
             msg += f"\n  💡 {self.suggestion}"
         super().__init__(msg)
 
     @classmethod
-    def from_response(cls, status_code: int, body: dict[str, Any]) -> APIError:
+    def from_response(cls, status_code: int, body: dict[str, Any], *, request_id: str | None = None) -> APIError:
         """Create the most specific error subclass from an API error response."""
         error = body.get("error", {})
         code = error.get("code", "UNKNOWN")
@@ -114,6 +121,7 @@ class APIError(MemoClawError):
             code=code,
             message=message,
             details=details,
+            request_id=request_id,
         )
 
 

--- a/python/tests/test_request_id_and_logging.py
+++ b/python/tests/test_request_id_and_logging.py
@@ -1,0 +1,49 @@
+"""Tests for request ID surfacing and debug logging."""
+
+import logging
+
+from memoclaw.errors import APIError, NotFoundError
+
+
+class TestRequestId:
+    def test_request_id_in_error(self):
+        err = NotFoundError(404, "NOT_FOUND", "Memory not found", request_id="req-abc-123")
+        assert err.request_id == "req-abc-123"
+        assert "req-abc-123" in str(err)
+
+    def test_request_id_none_when_absent(self):
+        err = APIError(404, "NOT_FOUND", "Memory not found")
+        assert err.request_id is None
+        assert "request-id" not in str(err)
+
+    def test_from_response_passes_request_id(self):
+        err = APIError.from_response(
+            404,
+            {"error": {"code": "NOT_FOUND", "message": "Not found"}},
+            request_id="req-xyz-789",
+        )
+        assert isinstance(err, NotFoundError)
+        assert err.request_id == "req-xyz-789"
+        assert "req-xyz-789" in str(err)
+
+    def test_from_response_no_request_id(self):
+        err = APIError.from_response(
+            404,
+            {"error": {"code": "NOT_FOUND", "message": "Not found"}},
+        )
+        assert err.request_id is None
+
+
+class TestDebugLogging:
+    def test_memoclaw_logger_exists(self):
+        """The memoclaw logger should be accessible via logging.getLogger."""
+        log = logging.getLogger("memoclaw")
+        assert log is not None
+        assert log.name == "memoclaw"
+
+    def test_logger_no_output_by_default(self, caplog):
+        """Logger should not produce output without explicit configuration."""
+        log = logging.getLogger("memoclaw")
+        with caplog.at_level(logging.WARNING, logger="memoclaw"):
+            log.debug("this should not appear")
+        assert "this should not appear" not in caplog.text

--- a/typescript/src/__tests__/client.test.ts
+++ b/typescript/src/__tests__/client.test.ts
@@ -18,7 +18,9 @@ function mockFetch(responses: Array<{ status: number; body?: unknown; ok?: boole
   return vi.fn(async () => {
     const resp = responses[callIndex] ?? responses[responses.length - 1]!;
     callIndex++;
-    const hdrs = new Map(Object.entries(resp.headers ?? {}));
+    // Normalise header keys to lowercase for consistent lookup
+    const rawHeaders = resp.headers ?? {};
+    const hdrs = new Map(Object.entries(rawHeaders).map(([k, v]) => [k.toLowerCase(), v]));
     return {
       ok: resp.ok ?? (resp.status >= 200 && resp.status < 300),
       status: resp.status,
@@ -415,5 +417,68 @@ describe('getMemoryGraph', () => {
     expect(graph.size).toBe(2);
     expect(graph.has('m1')).toBe(true);
     expect(graph.has('m2')).toBe(true);
+  });
+});
+
+describe('requestId', () => {
+  it('attaches x-request-id to error on non-2xx response', async () => {
+    const f = mockFetch([{
+      status: 404,
+      body: { error: { code: 'NOT_FOUND', message: 'Memory not found' } },
+      headers: { 'x-request-id': 'req-abc-123' },
+    }]);
+    const client = createClient(f);
+    try {
+      await client.get('nonexistent');
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MemoClawError);
+      const e = err as import('../errors.js').MemoClawError;
+      expect(e.requestId).toBe('req-abc-123');
+      expect(e.toString()).toContain('req-abc-123');
+    }
+  });
+
+  it('requestId is undefined when header is absent', async () => {
+    const f = mockFetch([{
+      status: 404,
+      body: { error: { code: 'NOT_FOUND', message: 'Memory not found' } },
+    }]);
+    const client = createClient(f);
+    try {
+      await client.get('nonexistent');
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      const e = err as import('../errors.js').MemoClawError;
+      expect(e.requestId).toBeUndefined();
+    }
+  });
+});
+
+describe('debug logging', () => {
+  it('calls logger.debug on request and response', async () => {
+    const debugFn = vi.fn();
+    const f = mockFetch([{ status: 200, body: { wallet: '0x', free_tier_remaining: 10, free_tier_total: 100, free_tier_used: 90 } }]);
+    const client = new MemoClawClient({
+      privateKey: TEST_PRIVATE_KEY,
+      baseUrl: BASE_URL,
+      fetch: f,
+      logger: { debug: debugFn },
+    });
+    await client.status();
+    // Should have at least a request log and a response log
+    expect(debugFn).toHaveBeenCalled();
+    const calls = debugFn.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(calls.some((c: string) => c.includes('GET') && c.includes('/v1/free-tier/status'))).toBe(true);
+    expect(calls.some((c: string) => c.includes('200'))).toBe(true);
+  });
+
+  it('does not log when debug is not set', async () => {
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const f = mockFetch([{ status: 200, body: { wallet: '0x', free_tier_remaining: 10, free_tier_total: 100, free_tier_used: 90 } }]);
+    const client = createClient(f);
+    await client.status();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -76,6 +76,11 @@ export interface RequestOptions {
   timeout?: number;
 }
 
+/** Minimal logger interface accepted by the SDK. */
+export interface Logger {
+  debug(message: string, ...args: unknown[]): void;
+}
+
 /** Hook called before each request. Can modify the body. */
 export type BeforeRequestHook = (method: string, path: string, body?: unknown) => unknown | void;
 /** Hook called after each successful response. */
@@ -106,6 +111,7 @@ export class MemoClawClient {
   private readonly _beforeRequestHooks: BeforeRequestHook[] = [];
   private readonly _afterResponseHooks: AfterResponseHook[] = [];
   private readonly _onErrorHooks: OnErrorHook[] = [];
+  private readonly _logger?: Logger;
 
   constructor(options: MemoClawOptions = {}) {
     const config = loadConfig(options.configPath);
@@ -148,6 +154,13 @@ export class MemoClawClient {
     this.maxRetries = options.maxRetries ?? 2;
     this.retryDelay = options.retryDelay ?? 500;
     this.timeout = options.timeout ?? 0;
+
+    // Debug logging: accepts a custom Logger or `debug: true` for console output
+    if (options.logger) {
+      this._logger = options.logger;
+    } else if (options.debug) {
+      this._logger = { debug: (msg: string, ...args: unknown[]) => console.debug(`[memoclaw] ${msg}`, ...args) };
+    }
   }
 
   /** Register a hook called before each request. Returns this for chaining. */
@@ -202,6 +215,9 @@ export class MemoClawClient {
 
     const jsonBody = processedBody !== undefined ? JSON.stringify(processedBody) : undefined;
 
+    this._logger?.debug(`${method} ${path}`, query ? `?${new URLSearchParams(query)}` : '');
+    const startTime = Date.now();
+
     // Combine caller signal/timeout with client-level timeout
     const signals: AbortSignal[] = [];
     if (options?.signal) signals.push(options.signal);
@@ -251,12 +267,17 @@ export class MemoClawClient {
         const message = errorBody?.error?.message ?? `HTTP ${res.status}`;
         const details = errorBody?.error?.details;
         lastError = createError(res.status, code, message, details);
+        lastError.requestId = res.headers?.get('x-request-id') ?? undefined;
 
+        this._logger?.debug(`${method} ${path} → ${res.status} [${code}], retrying in ${delay}ms (attempt ${attempt + 1}/${this.maxRetries})`);
         await new Promise((resolve) => setTimeout(resolve, delay));
         continue;
       }
 
       if (res.ok) {
+        const duration = Date.now() - startTime;
+        const reqId = res.headers?.get('x-request-id') ?? undefined;
+        this._logger?.debug(`${method} ${path} → ${res.status} (${duration}ms)`, reqId ? `req=${reqId}` : '');
         let data = (await res.json()) as T;
         // Run after-response hooks
         for (const hook of this._afterResponseHooks) {
@@ -278,11 +299,17 @@ export class MemoClawClient {
       const details = errorBody?.error?.details;
 
       lastError = createError(res.status, code, message, details);
+      lastError.requestId = res.headers?.get('x-request-id') ?? undefined;
+
+      const duration = Date.now() - startTime;
+      this._logger?.debug(`${method} ${path} → ${res.status} [${code}] (${duration}ms)`, lastError.requestId ? `req=${lastError.requestId}` : '');
 
       if (!RETRYABLE_STATUS_CODES.has(res.status)) {
         for (const hook of this._onErrorHooks) hook(method, path, lastError);
         throw lastError;
       }
+
+      this._logger?.debug(`Retrying ${method} ${path} (attempt ${attempt + 1}/${this.maxRetries})`);
     }
 
     if (lastError) {

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -62,6 +62,8 @@ function getSuggestion(status: number, code: string): string | undefined {
 export class MemoClawError extends Error {
   /** Actionable suggestion for how to fix this error. */
   public readonly suggestion?: string;
+  /** Server-side request ID from the `x-request-id` response header, if available. */
+  public requestId?: string;
 
   constructor(
     public readonly status: number,
@@ -77,6 +79,7 @@ export class MemoClawError extends Error {
   /** Returns a developer-friendly string including the suggestion when available. */
   override toString(): string {
     let str = `${this.name} [${this.code}] (${this.status}): ${this.message}`;
+    if (this.requestId) str += `\n  request-id: ${this.requestId}`;
     if (this.suggestion) str += `\n  → ${this.suggestion}`;
     return str;
   }

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -13,7 +13,7 @@ export {
   RateLimitError,
   createError,
 } from './errors.js';
-export type { BeforeRequestHook, AfterResponseHook, OnErrorHook, RequestOptions } from './client.js';
+export type { BeforeRequestHook, AfterResponseHook, OnErrorHook, RequestOptions, Logger } from './client.js';
 export {
   RecallQuery,
   AsyncRecallQuery,

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -502,4 +502,8 @@ export interface MemoClawOptions {
    *  `signal` options take precedence over (and are combined with) this
    *  default via `AbortSignal.any`. Pass `0` to disable. */
   timeout?: number;
+  /** Enable debug logging to console. For custom output, pass `logger` instead. */
+  debug?: boolean;
+  /** Custom logger for SDK debug output. Must implement `debug(message, ...args)`. */
+  logger?: { debug(message: string, ...args: unknown[]): void };
 }


### PR DESCRIPTION
## What

Adds two developer experience improvements to both TypeScript and Python SDKs:

### Request ID surfacing (Fixes #71)
- Read `x-request-id` response header and attach to error objects
- **TypeScript**: `MemoClawError.requestId` property
- **Python**: `APIError.request_id` attribute  
- Included in error `.toString()` / `__str__` output for easy support tickets

### Debug logging (Fixes #70)
- **TypeScript**: `debug: true` option or custom `logger: { debug() }` interface
- **Python**: stdlib `logging.getLogger('memoclaw')` at DEBUG level
- Logs: method, path, status, duration, retry attempts, request IDs
- No output by default (opt-in only)

## Tests
- TS: 162 tests pass (3 new tests for requestId + debug logging)
- Python: 198 tests pass (5 new tests for request_id + logging)

Fixes #70
Fixes #71