### PR TITLE
feat(ts): support wallet-only mode for free endpoints

### DIFF
--- a/typescript/src/__tests__/client.test.ts
+++ b/typescript/src/__tests__/client.test.ts
@@ -45,11 +45,25 @@ function createClient(fetchFn: typeof globalThis.fetch) {
 
 describe('MemoClawClient', () => {
   describe('constructor', () => {
-    it('throws if no private key is available', () => {
+    it('throws if neither privateKey nor wallet is available', () => {
+      const origKey = process.env.MEMOCLAW_PRIVATE_KEY;
+      const origWallet = process.env.MEMOCLAW_WALLET;
+      delete process.env.MEMOCLAW_PRIVATE_KEY;
+      delete process.env.MEMOCLAW_WALLET;
+      try {
+        expect(() => new MemoClawClient({})).toThrow('Authentication required');
+      } finally {
+        if (origKey !== undefined) process.env.MEMOCLAW_PRIVATE_KEY = origKey;
+        if (origWallet !== undefined) process.env.MEMOCLAW_WALLET = origWallet;
+      }
+    });
+
+    it('accepts wallet-only mode without private key', () => {
       const orig = process.env.MEMOCLAW_PRIVATE_KEY;
       delete process.env.MEMOCLAW_PRIVATE_KEY;
       try {
-        expect(() => new MemoClawClient({ wallet: '0xTest' })).toThrow('private key is required for API authentication');
+        const client = new MemoClawClient({ wallet: '0xTestWallet', fetch: mockFetch([]) });
+        expect(client).toBeDefined();
       } finally {
         if (orig !== undefined) process.env.MEMOCLAW_PRIVATE_KEY = orig;
       }
@@ -480,5 +494,83 @@ describe('debug logging', () => {
     await client.status();
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
+  });
+});
+
+describe('wallet-only mode', () => {
+  function createWalletOnlyClient(fetchFn: typeof globalThis.fetch) {
+    const orig = process.env.MEMOCLAW_PRIVATE_KEY;
+    delete process.env.MEMOCLAW_PRIVATE_KEY;
+    try {
+      return new MemoClawClient({
+        wallet: '0x1234567890abcdef1234567890abcdef12345678',
+        baseUrl: BASE_URL,
+        fetch: fetchFn,
+      });
+    } finally {
+      if (orig !== undefined) process.env.MEMOCLAW_PRIVATE_KEY = orig;
+    }
+  }
+
+  it('free endpoints work with wallet-only auth', async () => {
+    const f = mockFetch([{ status: 200, body: { memories: [], total: 0, limit: 20, offset: 0 } }]);
+    const client = createWalletOnlyClient(f);
+    const result = await client.list();
+    expect(result.total).toBe(0);
+    // Should send plain wallet address as auth header
+    expect(f).toHaveBeenCalledWith(
+      expect.stringContaining('/v1/memories'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-wallet-auth': '0x1234567890abcdef1234567890abcdef12345678',
+        }),
+      }),
+    );
+  });
+
+  it('status() works with wallet-only auth', async () => {
+    const f = mockFetch([{ status: 200, body: { wallet: '0x', free_tier_remaining: 50, free_tier_total: 100, free_tier_used: 50 } }]);
+    const client = createWalletOnlyClient(f);
+    const result = await client.status();
+    expect(result.free_tier_remaining).toBe(50);
+  });
+
+  it('store() throws in wallet-only mode', async () => {
+    const client = createWalletOnlyClient(mockFetch([]));
+    await expect(client.store({ content: 'test' })).rejects.toThrow('store() requires a private key');
+  });
+
+  it('recall() throws in wallet-only mode', async () => {
+    const client = createWalletOnlyClient(mockFetch([]));
+    await expect(client.recall({ query: 'test' })).rejects.toThrow('recall() requires a private key');
+  });
+
+  it('storeBatch() throws in wallet-only mode', async () => {
+    const client = createWalletOnlyClient(mockFetch([]));
+    await expect(client.storeBatch([{ content: 'a' }])).rejects.toThrow('storeBatch() requires a private key');
+  });
+
+  it('update() throws in wallet-only mode', async () => {
+    const client = createWalletOnlyClient(mockFetch([]));
+    await expect(client.update('id', { content: 'new' })).rejects.toThrow('update() requires a private key');
+  });
+
+  it('ingest() throws in wallet-only mode', async () => {
+    const client = createWalletOnlyClient(mockFetch([]));
+    await expect(client.ingest({ text: 'hello' })).rejects.toThrow('ingest() requires a private key');
+  });
+
+  it('get() works in wallet-only mode (free endpoint)', async () => {
+    const f = mockFetch([{ status: 200, body: { id: 'mem-1', content: 'test', importance: 0.5, memory_type: 'general', namespace: 'default', created_at: '2025-01-01', metadata: {} } }]);
+    const client = createWalletOnlyClient(f);
+    const result = await client.get('mem-1');
+    expect(result.id).toBe('mem-1');
+  });
+
+  it('delete() works in wallet-only mode (free endpoint)', async () => {
+    const f = mockFetch([{ status: 200, body: { deleted: true } }]);
+    const client = createWalletOnlyClient(f);
+    const result = await client.delete('mem-1');
+    expect(result.deleted).toBe(true);
   });
 });

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -103,7 +103,7 @@ export type OnErrorHook = (method: string, path: string, error: MemoClawError) =
 export class MemoClawClient {
   private readonly baseUrl: string;
   private readonly wallet: string;
-  private readonly _account: PrivateKeyAccount;
+  private readonly _account: PrivateKeyAccount | null;
   private readonly _fetch: typeof globalThis.fetch;
   private readonly maxRetries: number;
   private readonly retryDelay: number;
@@ -116,29 +116,26 @@ export class MemoClawClient {
   constructor(options: MemoClawOptions = {}) {
     const config = loadConfig(options.configPath);
 
-    // Resolve private key — required for API authentication (signed wallet auth)
+    // Resolve private key (optional — allows wallet-only mode for free endpoints)
     const privateKey = options.privateKey
       ?? process.env.MEMOCLAW_PRIVATE_KEY
       ?? config.privateKey;
 
-    if (!privateKey) {
-      throw new Error(
-        'A private key is required for API authentication. '
-        + 'Pass privateKey option, set MEMOCLAW_PRIVATE_KEY, '
-        + 'or run `memoclaw init` to create ~/.memoclaw/config.json.',
-      );
+    if (privateKey) {
+      const hex = (privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`) as Hex;
+      this._account = privateKeyToAccount(hex);
+    } else {
+      this._account = null;
     }
 
-    const hex = (privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`) as Hex;
-    this._account = privateKeyToAccount(hex);
-
     const wallet = options.wallet
-      ?? this._account.address
+      ?? this._account?.address
       ?? process.env.MEMOCLAW_WALLET
       ?? config.wallet;
     if (!wallet) {
       throw new Error(
-        'wallet is required. Pass wallet option, set MEMOCLAW_WALLET, '
+        'Authentication required. Pass privateKey (for full access) or wallet (for free endpoints), '
+        + 'set MEMOCLAW_PRIVATE_KEY / MEMOCLAW_WALLET, '
         + 'or run `memoclaw init` to create ~/.memoclaw/config.json.',
       );
     }
@@ -183,6 +180,17 @@ export class MemoClawClient {
 
   // ── Internal helpers ───────────────────────────────
 
+  /** Throw if the client is in wallet-only mode (no private key). */
+  private requireSignedAuth(method: string): void {
+    if (!this._account) {
+      throw new Error(
+        `${method}() requires a private key for signed authentication. `
+        + 'Pass privateKey option, set MEMOCLAW_PRIVATE_KEY, '
+        + 'or run `memoclaw init`.',
+      );
+    }
+  }
+
   private async request<T>(
     method: string,
     path: string,
@@ -203,12 +211,16 @@ export class MemoClawClient {
       if (result !== undefined) processedBody = result;
     }
 
-    // Generate signed wallet auth header: {address}:{timestamp}:{signature}
-    const timestamp = Math.floor(Date.now() / 1000).toString();
-    const authMessage = `memoclaw-auth:${timestamp}`;
-    const signature = await this._account.signMessage({ message: authMessage });
-    const walletHeader = `${this._account.address}:${timestamp}:${signature}`;
-    const headers: Record<string, string> = { 'x-wallet-auth': walletHeader };
+    // Generate auth header — signed if private key is available, plain wallet otherwise
+    const headers: Record<string, string> = {};
+    if (this._account) {
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const authMessage = `memoclaw-auth:${timestamp}`;
+      const signature = await this._account.signMessage({ message: authMessage });
+      headers['x-wallet-auth'] = `${this._account.address}:${timestamp}:${signature}`;
+    } else {
+      headers['x-wallet-auth'] = this.wallet;
+    }
     if (processedBody !== undefined) {
       headers['Content-Type'] = 'application/json';
     }
@@ -322,6 +334,7 @@ export class MemoClawClient {
 
   /** Store a single memory. */
   async store(request: StoreRequest, options?: RequestOptions): Promise<StoreResponse> {
+    this.requireSignedAuth('store');
     if (!request.content?.trim()) {
       throw new Error('content must be a non-empty string');
     }
@@ -330,6 +343,7 @@ export class MemoClawClient {
 
   /** Store multiple memories in a single request (up to 100). */
   async storeBatch(memories: StoreRequest[], options?: RequestOptions): Promise<StoreBatchResponse> {
+    this.requireSignedAuth('storeBatch');
     if (!memories.length) {
       throw new Error('memories array must not be empty');
     }
@@ -355,6 +369,7 @@ export class MemoClawClient {
 
   /** Recall memories via semantic search. */
   async recall(request: RecallRequest, options?: RequestOptions): Promise<RecallResponse> {
+    this.requireSignedAuth('recall');
     if (!request.query?.trim()) {
       throw new Error('query must be a non-empty string');
     }
@@ -395,12 +410,14 @@ export class MemoClawClient {
 
   /** Update a memory by ID. */
   async update(id: string, request: UpdateMemoryRequest, options?: RequestOptions): Promise<Memory> {
+    this.requireSignedAuth('update');
     if (!id?.trim()) throw new Error('id must be a non-empty string');
     return this.request<Memory>('PATCH', `/v1/memories/${encodeURIComponent(id)}`, request, undefined, options);
   }
 
   /** Update multiple memories in a single request (up to 100). */
   async updateBatch(updates: UpdateBatchItem[], options?: RequestOptions): Promise<UpdateBatchResponse> {
+    this.requireSignedAuth('updateBatch');
     if (!updates.length) {
       throw new Error('updates array must not be empty');
     }
@@ -449,6 +466,7 @@ export class MemoClawClient {
 
   /** Ingest a conversation or text and auto-extract memories. */
   async ingest(request: IngestRequest, options?: RequestOptions): Promise<IngestResponse> {
+    this.requireSignedAuth('ingest');
     if (!request.messages?.length && !request.text?.trim()) {
       throw new Error('Either messages or text must be provided');
     }
@@ -462,6 +480,7 @@ export class MemoClawClient {
 
   /** Extract structured facts from a conversation via LLM. */
   async extract(request: ExtractRequest, options?: RequestOptions): Promise<ExtractResponse> {
+    this.requireSignedAuth('extract');
     if (!request.messages?.length) {
       throw new Error('messages must be a non-empty array');
     }
@@ -470,11 +489,13 @@ export class MemoClawClient {
 
   /** Merge similar memories by clustering. */
   async consolidate(request: ConsolidateRequest = {}, options?: RequestOptions): Promise<ConsolidateResponse> {
+    this.requireSignedAuth('consolidate');
     return this.request<ConsolidateResponse>('POST', '/v1/memories/consolidate', request, undefined, options);
   }
 
   /** Create a relationship between two memories. */
   async createRelation(memoryId: string, request: CreateRelationRequest, options?: RequestOptions): Promise<CreateRelationResponse> {
+    this.requireSignedAuth('createRelation');
     if (!memoryId?.trim()) throw new Error('memoryId must be a non-empty string');
     if (!request.target_id?.trim()) throw new Error('target_id must be a non-empty string');
     return this.request<CreateRelationResponse>(
@@ -525,6 +546,7 @@ export class MemoClawClient {
       auto_tag?: boolean;
     } & RequestOptions,
   ): Promise<MigrateResponse> {
+    this.requireSignedAuth('migrate');
     if (!files.length) {
       throw new Error('files array must not be empty');
     }
@@ -608,6 +630,7 @@ export class MemoClawClient {
 
   /** Assemble a context block from memories for LLM prompts. */
   async assembleContext(request: ContextRequest, options?: RequestOptions): Promise<ContextResponse> {
+    this.requireSignedAuth('assembleContext');
     if (!request.query?.trim()) throw new Error('query must be a non-empty string');
     return this.request<ContextResponse>('POST', '/v1/context', request, undefined, options);
   }

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -36,11 +36,24 @@ function createClient(fetch: typeof globalThis.fetch, opts?: Partial<{ maxRetrie
 }
 
 describe('MemoClawClient constructor', () => {
-  it('throws if no private key is available', () => {
+  it('throws if neither privateKey nor wallet is available', () => {
+    const origKey = process.env.MEMOCLAW_PRIVATE_KEY;
+    const origWallet = process.env.MEMOCLAW_WALLET;
+    delete process.env.MEMOCLAW_PRIVATE_KEY;
+    delete process.env.MEMOCLAW_WALLET;
+    try {
+      expect(() => new MemoClawClient({})).toThrow('Authentication required');
+    } finally {
+      if (origKey !== undefined) process.env.MEMOCLAW_PRIVATE_KEY = origKey;
+      if (origWallet !== undefined) process.env.MEMOCLAW_WALLET = origWallet;
+    }
+  });
+
+  it('allows wallet-only mode without private key', () => {
     const orig = process.env.MEMOCLAW_PRIVATE_KEY;
     delete process.env.MEMOCLAW_PRIVATE_KEY;
     try {
-      expect(() => new MemoClawClient({ wallet: WALLET })).toThrow('private key is required for API authentication');
+      expect(() => new MemoClawClient({ wallet: WALLET, fetch: mockFetch([]) })).not.toThrow();
     } finally {
       if (orig !== undefined) process.env.MEMOCLAW_PRIVATE_KEY = orig;
     }
@@ -420,11 +433,12 @@ describe('wallet signature auth', () => {
     expect(parts[2]).toMatch(/^0x[0-9a-f]+$/i); // hex signature
   });
 
-  it('throws when no privateKey is available', () => {
+  it('allows wallet-only mode in auth tests', () => {
     const orig = process.env.MEMOCLAW_PRIVATE_KEY;
     delete process.env.MEMOCLAW_PRIVATE_KEY;
     try {
-      expect(() => new MemoClawClient({ wallet: WALLET })).toThrow('private key is required for API authentication');
+      // Wallet-only mode should not throw
+      expect(() => new MemoClawClient({ wallet: WALLET, fetch: mockFetch([]) })).not.toThrow();
     } finally {
       if (orig !== undefined) process.env.MEMOCLAW_PRIVATE_KEY = orig;
     }


### PR DESCRIPTION
## What

Adds wallet-only mode to the TypeScript SDK, matching the Python SDK's existing support.

### Changes
- Constructor now accepts `wallet` without `privateKey`
- Free endpoints work with plain wallet address auth header
- Paid endpoints throw descriptive errors explaining a private key is needed
- Auth header: signed `{address}:{timestamp}:{signature}` with key, plain wallet address without

### Guarded (paid) endpoints
`store`, `storeBatch`, `recall`, `update`, `updateBatch`, `ingest`, `extract`, `consolidate`, `migrate`, `assembleContext`, `createRelation`

### Free (wallet-only) endpoints
`list`, `get`, `delete`, `deleteBatch`, `status`, `stats`, `listNamespaces`, `export`, `getHistory`, `textSearch`, `coreMemories`, `suggested`, `listRelations`, `deleteRelation`

### Tests
- 174 TS tests pass (12 new wallet-only mode tests)
- 198 Python tests pass (no regressions)

Fixes #63