### PR TITLE
fix: pass missing filters in iter_export/iterExport and remove unused import

### DIFF
--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from types import EllipsisType
 from urllib.parse import quote
@@ -397,6 +396,10 @@ class MemoClaw:
         tags: _list[str] | None = None,
         session_id: str | None = None,
         agent_id: str | None = None,
+        memory_type: MemoryType | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        include_deleted: bool | None = None,
         timeout: float | None = None,
     ) -> ListResponse:
         """List memories with pagination."""
@@ -408,6 +411,10 @@ class MemoClaw:
                 "tags": tags,
                 "session_id": session_id,
                 "agent_id": agent_id,
+                "memory_type": memory_type,
+                "before": before,
+                "after": after,
+                "include_deleted": include_deleted,
             }
         )
         data = self._run_request("GET", "/v1/memories", params=params, timeout=timeout)
@@ -1026,6 +1033,10 @@ class MemoClaw:
                 tags=tags,
                 session_id=session_id,
                 agent_id=agent_id,
+                memory_type=memory_type,
+                before=before,
+                after=after,
+                include_deleted=include_deleted,
             )
             yield from page.memories
             offset += len(page.memories)
@@ -1387,6 +1398,10 @@ class AsyncMemoClaw:
         tags: _list[str] | None = None,
         session_id: str | None = None,
         agent_id: str | None = None,
+        memory_type: MemoryType | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        include_deleted: bool | None = None,
         timeout: float | None = None,
     ) -> ListResponse:
         """List memories with pagination."""
@@ -1398,6 +1413,10 @@ class AsyncMemoClaw:
                 "tags": tags,
                 "session_id": session_id,
                 "agent_id": agent_id,
+                "memory_type": memory_type,
+                "before": before,
+                "after": after,
+                "include_deleted": include_deleted,
             }
         )
         data = await self._run_request("GET", "/v1/memories", params=params, timeout=timeout)
@@ -1998,6 +2017,10 @@ class AsyncMemoClaw:
                 tags=tags,
                 session_id=session_id,
                 agent_id=agent_id,
+                memory_type=memory_type,
+                before=before,
+                after=after,
+                include_deleted=include_deleted,
             )
             for memory in page.memories:
                 yield memory

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -400,6 +400,10 @@ export class MemoClawClient {
     if (params.namespace) query['namespace'] = params.namespace;
     if (params.session_id) query['session_id'] = params.session_id;
     if (params.agent_id) query['agent_id'] = params.agent_id;
+    if (params.memory_type) query['memory_type'] = params.memory_type;
+    if (params.before) query['before'] = params.before;
+    if (params.after) query['after'] = params.after;
+    if (params.include_deleted !== undefined) query['include_deleted'] = String(params.include_deleted);
     return this.request<ListMemoriesResponse>('GET', '/v1/memories', undefined, query, options);
   }
 
@@ -732,6 +736,10 @@ export class MemoClawClient {
         tags: filters.tags,
         session_id: filters.session_id,
         agent_id: filters.agent_id,
+        memory_type: filters.memory_type,
+        before: filters.before,
+        after: filters.after,
+        include_deleted: filters.include_deleted,
       });
       for (const mem of page.memories) {
         yield mem;

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -126,6 +126,10 @@ export interface ListMemoriesParams {
   namespace?: string;
   session_id?: string;
   agent_id?: string;
+  memory_type?: MemoryType;
+  before?: string;
+  after?: string;
+  include_deleted?: boolean;
 }
 
 export interface UpdateMemoryRequest {


### PR DESCRIPTION
## Summary

Fixes two bugs in the SDK:

### 1. iter_export/iterExport silently ignores filters (Fixes #93)

`iter_export()` (Python) and `iterExport()` (TypeScript) accepted `memory_type`, `before`, `after`, and `include_deleted` parameters but never passed them to the underlying `list()` call, silently ignoring them.

**Fix:** Added these filter params to `list()` in both Python (sync + async) and TypeScript clients, and updated `iter_export`/`iterExport` to forward them.

### 2. Unused `os` import in Python client (Fixes #94)

`python/src/memoclaw/client.py` imported `os` but never used it.

**Fix:** Removed the unused import.

## Tests

- ✅ Python: 200 tests pass
- ✅ TypeScript: 174 tests pass
- ✅ mypy: no issues
- ✅ tsc --noEmit: no issues