### PR TITLE
fix: add missing deleteBatch/iterExport tests and empty wallet validation

### DIFF
--- a/python/src/memoclaw/config.py
+++ b/python/src/memoclaw/config.py
@@ -97,15 +97,23 @@ def resolve_wallet_address(
 
     Returns ``None`` if no wallet address is available (private key mode
     derives the address automatically).
+
+    Raises:
+        ValueError: If an explicit empty string is passed.
     """
     if explicit is not None:
+        if not explicit.strip():
+            raise ValueError(
+                "wallet_address must be a non-empty string. "
+                "Pass a valid Ethereum address or omit the argument."
+            )
         return explicit
 
     env_wallet = os.environ.get("MEMOCLAW_WALLET")
-    if env_wallet:
+    if env_wallet and env_wallet.strip():
         return env_wallet
 
-    if config and config.wallet:
+    if config and config.wallet and config.wallet.strip():
         return config.wallet
 
     return None

--- a/python/tests/test_validation.py
+++ b/python/tests/test_validation.py
@@ -21,6 +21,20 @@ def async_client():
     return AsyncMemoClaw(private_key=TEST_PRIVATE_KEY)
 
 
+class TestConstructorValidation:
+    def test_empty_wallet_address_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            MemoClaw(wallet_address="")
+
+    def test_whitespace_wallet_address_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            MemoClaw(wallet_address="   ")
+
+    def test_async_empty_wallet_address_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            AsyncMemoClaw(wallet_address="")
+
+
 class TestSyncValidation:
     def test_store_empty_content(self, client: MemoClaw):
         with pytest.raises(ValueError, match="content"):

--- a/typescript/src/__tests__/client.test.ts
+++ b/typescript/src/__tests__/client.test.ts
@@ -58,6 +58,20 @@ describe('MemoClawClient', () => {
       }
     });
 
+    it('rejects empty string wallet address', () => {
+      const origKey = process.env.MEMOCLAW_PRIVATE_KEY;
+      const origWallet = process.env.MEMOCLAW_WALLET;
+      delete process.env.MEMOCLAW_PRIVATE_KEY;
+      delete process.env.MEMOCLAW_WALLET;
+      try {
+        expect(() => new MemoClawClient({ wallet: '' })).toThrow('Authentication required');
+        expect(() => new MemoClawClient({ wallet: '   ' })).toThrow('Authentication required');
+      } finally {
+        if (origKey !== undefined) process.env.MEMOCLAW_PRIVATE_KEY = origKey;
+        if (origWallet !== undefined) process.env.MEMOCLAW_WALLET = origWallet;
+      }
+    });
+
     it('accepts wallet-only mode without private key', () => {
       const orig = process.env.MEMOCLAW_PRIVATE_KEY;
       delete process.env.MEMOCLAW_PRIVATE_KEY;

--- a/typescript/src/__tests__/new-endpoints.test.ts
+++ b/typescript/src/__tests__/new-endpoints.test.ts
@@ -270,3 +270,116 @@ describe('textSearch', () => {
     expect(url).toContain('memory_type=correction');
   });
 });
+
+describe('deleteBatch', () => {
+  it('should POST /v1/memories/batch-delete', async () => {
+    const fetch = mockFetch([{
+      status: 200,
+      body: {
+        results: [
+          { id: 'mem-1', deleted: true },
+          { id: 'mem-2', deleted: true },
+        ],
+      },
+    }]);
+    const client = createClient(fetch);
+    const results = await client.deleteBatch(['mem-1', 'mem-2']);
+    expect(results).toHaveLength(2);
+    expect(results[0]!.deleted).toBe(true);
+    expect(results[0]!.id).toBe('mem-1');
+    expect(fetch).toHaveBeenCalledWith(
+      `${BASE_URL}/v1/memories/batch-delete`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('should throw on empty array', async () => {
+    const client = createClient(vi.fn());
+    await expect(client.deleteBatch([])).rejects.toThrow('ids array must not be empty');
+  });
+
+  it('should chunk large batches into groups of 50', async () => {
+    const ids = Array.from({ length: 75 }, (_, i) => `mem-${i}`);
+    const fetch = mockFetch([
+      {
+        status: 200,
+        body: {
+          results: ids.slice(0, 50).map((id) => ({ id, deleted: true })),
+        },
+      },
+      {
+        status: 200,
+        body: {
+          results: ids.slice(50).map((id) => ({ id, deleted: true })),
+        },
+      },
+    ]);
+    const client = createClient(fetch);
+    const results = await client.deleteBatch(ids);
+    expect(results).toHaveLength(75);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('iterExport', () => {
+  it('should paginate through memories', async () => {
+    const fetch = mockFetch([
+      {
+        status: 200,
+        body: {
+          memories: [
+            { id: 'mem-1', content: 'first' },
+            { id: 'mem-2', content: 'second' },
+          ],
+          total: 3,
+          limit: 2,
+          offset: 0,
+        },
+      },
+      {
+        status: 200,
+        body: {
+          memories: [{ id: 'mem-3', content: 'third' }],
+          total: 3,
+          limit: 2,
+          offset: 2,
+        },
+      },
+    ]);
+    const client = createClient(fetch);
+    const memories: unknown[] = [];
+    for await (const mem of client.iterExport({ batchSize: 2 })) {
+      memories.push(mem);
+    }
+    expect(memories).toHaveLength(3);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle empty result', async () => {
+    const fetch = mockFetch([{
+      status: 200,
+      body: { memories: [], total: 0, limit: 50, offset: 0 },
+    }]);
+    const client = createClient(fetch);
+    const memories: unknown[] = [];
+    for await (const mem of client.iterExport()) {
+      memories.push(mem);
+    }
+    expect(memories).toEqual([]);
+  });
+
+  it('should pass filter params', async () => {
+    const fetch = mockFetch([{
+      status: 200,
+      body: { memories: [], total: 0, limit: 50, offset: 0 },
+    }]);
+    const client = createClient(fetch);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _ of client.iterExport({ namespace: 'test', tags: ['a'] })) {
+      // consume
+    }
+    const url = (fetch as any).mock.calls[0][0] as string;
+    expect(url).toContain('namespace=test');
+    expect(url).toContain('tags=a');
+  });
+});

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -132,7 +132,7 @@ export class MemoClawClient {
       ?? this._account?.address
       ?? process.env.MEMOCLAW_WALLET
       ?? config.wallet;
-    if (!wallet) {
+    if (!wallet || !wallet.trim()) {
       throw new Error(
         'Authentication required. Pass privateKey (for full access) or wallet (for free endpoints), '
         + 'set MEMOCLAW_PRIVATE_KEY / MEMOCLAW_WALLET, '


### PR DESCRIPTION
## Summary

Fixes #102

### Changes

**TypeScript tests added:**
- `deleteBatch`: basic operation, empty array validation, chunking for 75 items (2 API calls)
- `iterExport`: pagination across multiple pages, empty result handling, filter param forwarding
- Empty/whitespace wallet rejection at construction time

**Python fixes:**
- `resolve_wallet_address()` now raises `ValueError` on empty/whitespace wallet addresses
- Also validates env var and config file values are non-empty
- 3 new tests for constructor wallet validation

**TypeScript fixes:**
- Wallet validation now uses `!wallet.trim()` to reject whitespace-only strings

### Test results
- TypeScript: 182 passed ✅
- Python: 235 passed ✅