### PR TITLE
fix(python): store_batch tags nesting, iter_memories filters, retry jitter

### DIFF
--- a/python/src/memoclaw/_client.py
+++ b/python/src/memoclaw/_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import random
 import time
 from typing import Any
 
@@ -145,8 +146,10 @@ class _SyncHTTPClient:
             except (httpx.ConnectError, httpx.ReadTimeout, httpx.WriteTimeout) as exc:
                 last_exc = exc
                 if attempt < self._max_retries:
+                    delay = _RETRY_BASE_DELAY * (2**attempt)
+                    jitter = delay * 0.25 * random.random()
                     logger.debug("Network error on %s %s, retrying (attempt %d/%d)", method, path, attempt + 1, self._max_retries)
-                    time.sleep(_RETRY_BASE_DELAY * (2**attempt))
+                    time.sleep(delay + jitter)
                     continue
                 raise
 
@@ -175,6 +178,7 @@ class _SyncHTTPClient:
                     delay = float(retry_after)
                 else:
                     delay = _RETRY_BASE_DELAY * (2**attempt)
+                    delay += delay * 0.25 * random.random()
                 logger.debug("Retrying %s %s in %.1fs (attempt %d/%d)", method, path, delay, attempt + 1, self._max_retries)
                 time.sleep(delay)
                 continue
@@ -267,8 +271,10 @@ class _AsyncHTTPClient:
             except (httpx.ConnectError, httpx.ReadTimeout, httpx.WriteTimeout) as exc:
                 last_exc = exc
                 if attempt < self._max_retries:
+                    delay = _RETRY_BASE_DELAY * (2**attempt)
+                    jitter = delay * 0.25 * random.random()
                     logger.debug("Network error on %s %s, retrying (attempt %d/%d)", method, path, attempt + 1, self._max_retries)
-                    await asyncio.sleep(_RETRY_BASE_DELAY * (2**attempt))
+                    await asyncio.sleep(delay + jitter)
                     continue
                 raise
 
@@ -297,6 +303,7 @@ class _AsyncHTTPClient:
                     delay = float(retry_after)
                 else:
                     delay = _RETRY_BASE_DELAY * (2**attempt)
+                    delay += delay * 0.25 * random.random()
                 logger.debug("Retrying %s %s in %.1fs (attempt %d/%d)", method, path, delay, attempt + 1, self._max_retries)
                 await asyncio.sleep(delay)
                 continue

--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -82,6 +82,17 @@ def _clean_body(body: dict[str, Any]) -> dict[str, Any]:
 MAX_BATCH_SIZE = 100
 
 
+def _normalize_store_input(m: StoreInput) -> dict[str, Any]:
+    """Serialize a StoreInput, nesting ``tags`` inside ``metadata`` to match the API schema."""
+    data = m.model_dump(exclude_none=True)
+    tags = data.pop("tags", None)
+    if tags is not None:
+        md: dict[str, Any] = data.get("metadata") or {}
+        md["tags"] = tags
+        data["metadata"] = md
+    return data
+
+
 def _validate_non_empty(value: str | None, name: str) -> None:
     """Raise ValueError if value is empty or whitespace-only."""
     if not value or not value.strip():
@@ -340,7 +351,7 @@ class MemoClaw:
                 f"Batch size {len(memories)} exceeds maximum of {MAX_BATCH_SIZE}"
             )
         items = [
-            m.model_dump(exclude_none=True) if isinstance(m, StoreInput) else m
+            _normalize_store_input(m) if isinstance(m, StoreInput) else m
             for m in memories
         ]
         data = self._run_request("POST", "/v1/store/batch", json={"memories": items}, timeout=timeout)
@@ -447,10 +458,15 @@ class MemoClaw:
         tags: _list[str] | None = None,
         session_id: str | None = None,
         agent_id: str | None = None,
+        memory_type: MemoryType | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        include_deleted: bool | None = None,
     ) -> Iterator[Memory]:
         """Iterate over all memories with automatic pagination.
 
         Yields individual :class:`Memory` objects, fetching pages transparently.
+        Supports all the same filters as :meth:`list`.
         """
         offset = 0
         while True:
@@ -461,6 +477,10 @@ class MemoClaw:
                 tags=tags,
                 session_id=session_id,
                 agent_id=agent_id,
+                memory_type=memory_type,
+                before=before,
+                after=after,
+                include_deleted=include_deleted,
             )
             yield from page.memories
             offset += len(page.memories)
@@ -1366,7 +1386,7 @@ class AsyncMemoClaw:
                 f"Batch size {len(memories)} exceeds maximum of {MAX_BATCH_SIZE}"
             )
         items = [
-            m.model_dump(exclude_none=True) if isinstance(m, StoreInput) else m
+            _normalize_store_input(m) if isinstance(m, StoreInput) else m
             for m in memories
         ]
         data = await self._run_request(
@@ -1475,10 +1495,15 @@ class AsyncMemoClaw:
         tags: _list[str] | None = None,
         session_id: str | None = None,
         agent_id: str | None = None,
+        memory_type: MemoryType | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        include_deleted: bool | None = None,
     ) -> AsyncIterator[Memory]:
         """Iterate over all memories with automatic pagination.
 
         Yields individual :class:`Memory` objects, fetching pages transparently.
+        Supports all the same filters as :meth:`list`.
         """
         offset = 0
         while True:
@@ -1489,6 +1514,10 @@ class AsyncMemoClaw:
                 tags=tags,
                 session_id=session_id,
                 agent_id=agent_id,
+                memory_type=memory_type,
+                before=before,
+                after=after,
+                include_deleted=include_deleted,
             )
             for mem in page.memories:
                 yield mem

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -593,6 +593,45 @@ class TestContextManager:
             assert result.free_tier_remaining == 1000
 
 
+class TestStoreBatch:
+    @respx.mock
+    def test_store_batch_nests_tags_in_metadata(self, client: MemoClaw):
+        """StoreInput.tags should be nested inside metadata, not sent as top-level field."""
+        from memoclaw import StoreInput
+
+        route = respx.post(f"{BASE_URL}/v1/store/batch").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "ids": ["m1", "m2"],
+                    "stored": True,
+                    "count": 2,
+                    "deduplicated_count": 0,
+                    "tokens_used": 84,
+                },
+            )
+        )
+        inputs = [
+            StoreInput(content="Memory A", tags=["tag1", "tag2"], importance=0.8),
+            StoreInput(content="Memory B", metadata={"existing": True}, tags=["tag3"]),
+        ]
+        result = client.store_batch(inputs)
+        assert result.count == 2
+
+        # Verify the request body has tags nested inside metadata
+        import json as json_mod
+        body = json_mod.loads(route.calls[0].request.content)
+        memories = body["memories"]
+        # First memory: tags should be inside metadata
+        assert "tags" not in memories[0] or "tags" in memories[0].get("metadata", {})
+        assert memories[0]["metadata"]["tags"] == ["tag1", "tag2"]
+        # Second memory: tags merged into existing metadata
+        assert memories[1]["metadata"]["tags"] == ["tag3"]
+        assert memories[1]["metadata"]["existing"] is True
+        # tags should NOT be a top-level field
+        assert "tags" not in {k for k in memories[0] if k != "metadata"}
+
+
 class TestIterMemories:
     @respx.mock
     def test_iter_memories_pagination(self, client: MemoClaw):
@@ -624,6 +663,39 @@ class TestIterMemories:
         assert len(memories) == 3
         assert [m.id for m in memories] == ["m1", "m2", "m3"]
         assert route.call_count == 2
+
+    @respx.mock
+    def test_iter_memories_with_filters(self, client: MemoClaw):
+        """iter_memories should pass memory_type, before, after, include_deleted to list()."""
+        mem_json = {
+            "id": "m1", "user_id": "u1", "namespace": "default",
+            "content": "mem 1", "embedding_model": "text-embedding-3-small",
+            "metadata": {}, "importance": 0.5, "memory_type": "preference",
+            "session_id": None, "agent_id": None,
+            "created_at": "2025-06-01T00:00:00Z",
+            "updated_at": "2025-06-01T00:00:00Z",
+            "accessed_at": "2025-06-01T00:00:00Z",
+            "access_count": 0, "deleted_at": None, "expires_at": None,
+            "pinned": False,
+        }
+        route = respx.get(f"{BASE_URL}/v1/memories").mock(
+            return_value=httpx.Response(200, json={
+                "memories": [mem_json],
+                "total": 1, "limit": 50, "offset": 0,
+            })
+        )
+        memories = list(client.iter_memories(
+            memory_type="preference",
+            after="2025-01-01T00:00:00Z",
+            before="2026-01-01T00:00:00Z",
+            include_deleted=True,
+        ))
+        assert len(memories) == 1
+        url_str = str(route.calls[0].request.url)
+        assert "memory_type=preference" in url_str
+        assert "after=2025-01-01" in url_str
+        assert "before=2026-01-01" in url_str
+        assert "include_deleted=true" in url_str
 
     @respx.mock
     def test_iter_export_pagination(self, client: MemoClaw):


### PR DESCRIPTION
## Summary

Fixes three Python SDK bugs found during code audit:

### Bug Fixes

1. **store_batch tags nesting** (Fixes #111)
   - `StoreInput.tags` are now properly nested inside `metadata` when using `store_batch()`
   - Previously tags were sent as a top-level field, which doesn't match the API schema
   - Added `_normalize_store_input()` helper that transforms tags into metadata, matching `store()` behavior

2. **iter_memories missing filters** (Fixes #112)
   - Added `memory_type`, `before`, `after`, and `include_deleted` parameters to both sync and async `iter_memories()`
   - Brings Python SDK to parity with TypeScript SDK which uses `Omit<ListMemoriesParams, 'offset'>`

3. **Retry jitter** (Fixes #113)
   - Added 25% random jitter to retry delays in both `_SyncHTTPClient` and `_AsyncHTTPClient`
   - Prevents thundering herd when multiple clients fail and retry simultaneously
   - Matches existing TypeScript SDK behavior

### Tests
- Added `TestStoreBatch.test_store_batch_nests_tags_in_metadata` — verifies tags are nested in metadata
- Added `TestIterMemories.test_iter_memories_with_filters` — verifies new filter parameters are passed through
- All 208 Python tests pass, all 182 TypeScript tests pass, all 11 MCP server tests pass