### PR TITLE
fix: Python batch consistency, RecallBuilder.after, AsyncRelationBuilder

### DIFF
--- a/python/src/memoclaw/__init__.py
+++ b/python/src/memoclaw/__init__.py
@@ -60,6 +60,7 @@ from .types import (
 from .builders import (
     AsyncMemoryFilter,
     AsyncRecallQuery,
+    AsyncRelationBuilder,
     AsyncStoreBuilder,
     BatchStore,
     MemoryFilter,
@@ -134,6 +135,7 @@ __all__ = [
     "MemoryFilter",
     "AsyncMemoryFilter",
     "RelationBuilder",
+    "AsyncRelationBuilder",
     "BatchStore",
     "StoreBuilder",
     "AsyncStoreBuilder",

--- a/python/src/memoclaw/builders.py
+++ b/python/src/memoclaw/builders.py
@@ -179,6 +179,7 @@ class RecallBuilder:
         self._agent_id: str | None = None
         self._include_relations: bool | None = None
         self._memory_type: MemoryType | None = None
+        self._after: str | None = None
 
     def query(self, query: str) -> RecallBuilder:
         """Set the search query."""
@@ -227,6 +228,11 @@ class RecallBuilder:
         self._memory_type = memory_type
         return self
 
+    def after(self, after: str) -> RecallBuilder:
+        """Filter memories created after this ISO timestamp."""
+        self._after = after
+        return self
+
     def build(self) -> dict[str, Any]:
         """Build the recall parameters dict."""
         if not self._query:
@@ -247,12 +253,14 @@ class RecallBuilder:
         if self._include_relations is not None:
             params["include_relations"] = self._include_relations
         
-        if self._tags is not None or self._memory_type is not None:
+        if self._tags is not None or self._memory_type is not None or self._after is not None:
             filters: dict[str, Any] = {}
             if self._tags is not None:
                 filters["tags"] = self._tags
             if self._memory_type is not None:
                 filters["memory_type"] = self._memory_type
+            if self._after is not None:
+                filters["after"] = self._after
             params["filters"] = filters
         
         return params
@@ -606,6 +614,49 @@ class RelationBuilder:
         return results
 
 
+class AsyncRelationBuilder:
+    """Async version of RelationBuilder for use with AsyncMemoClaw.
+
+    Example::
+
+        async with AsyncMemoClaw() as client:
+            results = await (AsyncRelationBuilder(client, "memory-123")
+                .relate_to("memory-456", "related_to")
+                .relate_to("memory-789", "supports")
+                .create_all())
+    """
+
+    def __init__(self, client: "AsyncMemoClaw", source_id: str) -> None:
+        self._client = client
+        self._source_id = source_id
+        self._relations: list[tuple[str, RelationType, dict[str, Any] | None]] = []
+
+    def relate_to(
+        self,
+        target_id: str,
+        relation_type: RelationType,
+        metadata: dict[str, Any] | None = None,
+    ) -> AsyncRelationBuilder:
+        """Add a relation to be created."""
+        self._relations.append((target_id, relation_type, metadata))
+        return self
+
+    async def create_all(self) -> list[dict[str, Any]]:
+        """Create all pending relations."""
+        results = []
+        for target_id, relation_type, metadata in self._relations:
+            result = await self._client.create_relation(
+                self._source_id, target_id, relation_type, metadata=metadata
+            )
+            results.append({
+                "id": result.id,
+                "target_id": target_id,
+                "relation_type": relation_type,
+            })
+        self._relations.clear()
+        return results
+
+
 class BatchStore:
     """Efficient batch storage with automatic chunking.
 
@@ -917,6 +968,7 @@ __all__ = [
     "MemoryFilter",
     "AsyncMemoryFilter",
     "RelationBuilder",
+    "AsyncRelationBuilder",
     "BatchStore",
     "StoreBuilder",
     "AsyncStoreBuilder",

--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -630,7 +630,7 @@ class MemoClaw:
         Returns a list of :class:`DeleteBatchItemResult` objects.
         """
         if not memory_ids:
-            return []
+            raise ValueError("memory_ids list must not be empty")
         results: _list[DeleteBatchItemResult] = []
         for i in range(0, len(memory_ids), 50):
             chunk = memory_ids[i : i + 50]
@@ -1692,7 +1692,7 @@ class AsyncMemoClaw:
         Returns a list of :class:`DeleteBatchItemResult` objects.
         """
         if not memory_ids:
-            return []
+            raise ValueError("memory_ids list must not be empty")
         results: _list[DeleteBatchItemResult] = []
         for i in range(0, len(memory_ids), 50):
             chunk = memory_ids[i : i + 50]

--- a/python/tests/test_async_client.py
+++ b/python/tests/test_async_client.py
@@ -194,8 +194,8 @@ class TestAsyncDelete:
     @respx.mock
     @pytest.mark.asyncio
     async def test_delete_batch_empty(self, client: AsyncMemoClaw):
-        results = await client.delete_batch([])
-        assert results == []
+        with pytest.raises(ValueError, match="memory_ids list must not be empty"):
+            await client.delete_batch([])
         await client.close()
 
 

--- a/python/tests/test_builders.py
+++ b/python/tests/test_builders.py
@@ -621,3 +621,124 @@ class TestStoreBuilder:
         """Test that invalid importance raises ValueError."""
         with pytest.raises(ValueError, match="importance must be between"):
             StoreBuilder(client).content("test").importance(1.5)
+
+
+class TestRecallBuilderAfter:
+    """Test that RecallBuilder supports the after() filter."""
+
+    def test_after_included_in_filters(self):
+        params = (
+            RecallBuilder()
+            .query("test query")
+            .after("2026-01-01T00:00:00Z")
+            .build()
+        )
+        assert params["query"] == "test query"
+        assert "filters" in params
+        assert params["filters"]["after"] == "2026-01-01T00:00:00Z"
+
+    def test_after_combined_with_other_filters(self):
+        params = (
+            RecallBuilder()
+            .query("test")
+            .tags(["important"])
+            .memory_type("preference")
+            .after("2026-03-01T00:00:00Z")
+            .build()
+        )
+        filters = params["filters"]
+        assert filters["tags"] == ["important"]
+        assert filters["memory_type"] == "preference"
+        assert filters["after"] == "2026-03-01T00:00:00Z"
+
+    def test_after_only_filter(self):
+        params = (
+            RecallBuilder()
+            .query("test")
+            .after("2026-01-01T00:00:00Z")
+            .build()
+        )
+        assert params["filters"] == {"after": "2026-01-01T00:00:00Z"}
+
+    def test_no_filters_when_none_set(self):
+        params = RecallBuilder().query("test").build()
+        assert "filters" not in params
+
+
+class TestAsyncRelationBuilder:
+    """Test AsyncRelationBuilder for use with AsyncMemoClaw."""
+
+    @pytest.fixture
+    def async_client(self):
+        import httpx
+        import respx
+        from memoclaw import AsyncMemoClaw
+        c = AsyncMemoClaw(private_key="0x4c0883a69102937d6231471b5dbb6204fe512961708279f15a8f7e20b4e3b1fb")
+        return c
+
+    @pytest.mark.asyncio
+    async def test_create_all_relations(self, async_client):
+        import respx
+        from httpx import Response
+        from memoclaw.builders import AsyncRelationBuilder
+
+        with respx.mock:
+            route = respx.post(url__regex=r".*v1/memories/.*/relations").mock(
+                side_effect=[
+                    Response(201, json={
+                        "id": "rel-1",
+                        "source_id": "mem-123",
+                        "target_id": "mem-456",
+                        "relation_type": "related_to",
+                        "created_at": "2026-01-01T00:00:00Z",
+                    }),
+                    Response(201, json={
+                        "id": "rel-2",
+                        "source_id": "mem-123",
+                        "target_id": "mem-789",
+                        "relation_type": "supports",
+                        "created_at": "2026-01-01T00:00:00Z",
+                    }),
+                ]
+            )
+
+            builder = AsyncRelationBuilder(async_client, "mem-123")
+            results = await (
+                builder
+                .relate_to("mem-456", "related_to")
+                .relate_to("mem-789", "supports")
+                .create_all()
+            )
+
+            assert len(results) == 2
+            assert results[0]["id"] == "rel-1"
+            assert results[0]["target_id"] == "mem-456"
+            assert results[0]["relation_type"] == "related_to"
+            assert results[1]["id"] == "rel-2"
+            assert results[1]["target_id"] == "mem-789"
+            assert route.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_create_all_clears_pending(self, async_client):
+        import respx
+        from httpx import Response
+        from memoclaw.builders import AsyncRelationBuilder
+
+        with respx.mock:
+            respx.post(url__regex=r".*v1/memories/.*/relations").mock(
+                return_value=Response(201, json={
+                    "id": "rel-1",
+                    "source_id": "mem-123",
+                    "target_id": "mem-456",
+                    "relation_type": "related_to",
+                    "created_at": "2026-01-01T00:00:00Z",
+                })
+            )
+
+            builder = AsyncRelationBuilder(async_client, "mem-123")
+            builder.relate_to("mem-456", "related_to")
+            await builder.create_all()
+            
+            # Second call should return empty since relations were cleared
+            results = await builder.create_all()
+            assert results == []

--- a/python/tests/test_new_features.py
+++ b/python/tests/test_new_features.py
@@ -116,8 +116,8 @@ class TestDeleteBatch:
 
     @respx.mock
     def test_delete_batch_empty(self, client: MemoClaw):
-        results = client.delete_batch([])
-        assert results == []
+        with pytest.raises(ValueError, match="memory_ids list must not be empty"):
+            client.delete_batch([])
 
     @respx.mock
     @pytest.mark.asyncio

--- a/python/tests/test_validation.py
+++ b/python/tests/test_validation.py
@@ -413,3 +413,16 @@ class TestImportanceValidation:
     async def test_async_update_importance_too_high(self, async_client: AsyncMemoClaw):
         with pytest.raises(ValueError, match="importance must be between"):
             await async_client.update("mem-1", importance=2.0)
+
+
+class TestDeleteBatchValidation:
+    def test_empty_list_raises(self, client: MemoClaw):
+        with pytest.raises(ValueError, match="memory_ids list must not be empty"):
+            client.delete_batch([])
+
+
+class TestAsyncDeleteBatchValidation:
+    @pytest.mark.asyncio
+    async def test_empty_list_raises(self, async_client: AsyncMemoClaw):
+        with pytest.raises(ValueError, match="memory_ids list must not be empty"):
+            await async_client.delete_batch([])


### PR DESCRIPTION
## Summary

Three Python SDK fixes bundled together:

### Bug: `delete_batch` empty input handling (#123)
- **Before:** `client.delete_batch([])` silently returned `[]`
- **After:** Raises `ValueError` (consistent with `store_batch`, `update_batch`, and TypeScript `deleteBatch`)
- Fixed in both sync `MemoClaw` and `AsyncMemoClaw`

### Bug: `RecallBuilder` missing `after()` filter (#124)
- TypeScript `RecallBuilder` had `after()` but Python didn't
- Added `_after` field, `after()` method, and inclusion in `build()` filters dict
- `RecallQuery`/`AsyncRecallQuery` already had this — now `RecallBuilder` has parity

### Enhancement: `AsyncRelationBuilder` (#125)
- Python had sync `RelationBuilder` for `MemoClaw` but no async equivalent
- Added `AsyncRelationBuilder` with async `create_all()` method
- Exported from package `__init__.py`

## Tests
- Updated 2 existing tests that expected `delete_batch([])` → `[]`
- Added 2 new tests for `delete_batch` validation
- Added 4 tests for `RecallBuilder.after()`
- Added 2 tests for `AsyncRelationBuilder`
- All 331 Python tests pass ✅
- All 234 TypeScript tests pass ✅

Fixes #123, Fixes #124, Fixes #125