### PR TITLE
fix: remove dead code + add AsyncMemoClaw.create() factory

### DIFF
--- a/python/src/memoclaw/_client.py
+++ b/python/src/memoclaw/_client.py
@@ -120,11 +120,6 @@ def _raise_for_status(response: httpx.Response) -> None:
     raise APIError.from_response(response.status_code, body, request_id=request_id)
 
 
-def _is_retryable(exc: BaseException) -> bool:
-    """Check if an exception is retryable (network errors)."""
-    return isinstance(exc, (httpx.ConnectError, httpx.ReadTimeout, httpx.WriteTimeout))
-
-
 def _try_x402_payment(
     response: httpx.Response,
 ) -> dict[str, str] | None:

--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -1349,6 +1349,50 @@ class AsyncMemoClaw:
         self._after_response_hooks: _list[AfterResponseHook] = []
         self._on_error_hooks: _list[OnErrorHook] = []
 
+    # ── Factory ──────────────────────────────────────────────────────────
+
+    @classmethod
+    async def create(
+        cls,
+        private_key: str | None = None,
+        *,
+        wallet_address: str | None = None,
+        base_url: str | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        max_retries: int | None = None,
+        pool_max_connections: int = DEFAULT_POOL_MAX_CONNECTIONS,
+        pool_max_keepalive: int = DEFAULT_POOL_MAX_KEEPALIVE_CONNECTIONS,
+        config_path: str | Path | None = None,
+        log_level: LogLevel | None = None,
+        log_format: LogFormat = "text",
+        validate_on_init: bool = True,
+    ) -> AsyncMemoClaw:
+        """Async factory that creates and optionally validates the client.
+
+        This mirrors the TypeScript SDK's ``MemoClawClient.create()`` pattern.
+        When *validate_on_init* is ``True`` (the default), ``ping()`` is called
+        to verify the connection before returning.
+
+        Example::
+
+            client = await AsyncMemoClaw.create(private_key="0x...")
+        """
+        client = cls(
+            private_key,
+            wallet_address=wallet_address,
+            base_url=base_url,
+            timeout=timeout,
+            max_retries=max_retries,
+            pool_max_connections=pool_max_connections,
+            pool_max_keepalive=pool_max_keepalive,
+            config_path=config_path,
+            log_level=log_level,
+            log_format=log_format,
+        )
+        if validate_on_init:
+            await client.ping()
+        return client
+
     # ── Auth helpers ────────────────────────────────────────────────────
 
     def _require_signed_auth(self, method_name: str) -> None:

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -791,3 +791,38 @@ class TestAsyncClient:
         async with AsyncMemoClaw(private_key=TEST_PRIVATE_KEY, base_url=BASE_URL) as c:
             result = await c.status()
             assert result.free_tier_remaining == 1000
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_create_factory(self):
+        """AsyncMemoClaw.create() validates connection via ping()."""
+        respx.get(f"{BASE_URL}/v1/free-tier/status").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "wallet": "0xabc",
+                    "free_tier_remaining": 100,
+                    "free_tier_total": 100,
+                    "free_tier_used": 0,
+                },
+            )
+        )
+        client = await AsyncMemoClaw.create(
+            private_key=TEST_PRIVATE_KEY,
+            base_url=BASE_URL,
+            validate_on_init=True,
+        )
+        assert client is not None
+        await client.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_create_factory_no_validate(self):
+        """AsyncMemoClaw.create(validate_on_init=False) skips ping."""
+        client = await AsyncMemoClaw.create(
+            private_key=TEST_PRIVATE_KEY,
+            base_url=BASE_URL,
+            validate_on_init=False,
+        )
+        assert client is not None
+        await client.close()


### PR DESCRIPTION
## Changes

### Bug fix: Remove dead code (Fixes #136)
- Removed the unused `_is_retryable()` function from `python/src/memoclaw/_client.py`
- The retry logic catches exceptions inline; this function was defined but never called

### Enhancement: Add `AsyncMemoClaw.create()` factory (Fixes #137)
- Added `AsyncMemoClaw.create()` classmethod with `validate_on_init` parameter
- Mirrors the TypeScript SDK's `MemoClawClient.create()` static async factory pattern
- When `validate_on_init=True` (default), calls `ping()` to verify the connection before returning
- Added 2 tests for the factory method (with and without validation)

### Audit findings filed as issues
- #138: Python integrations (LangChain/LlamaIndex) only support sync `MemoClaw`, not `AsyncMemoClaw`

## Test results
- Python: 360 passed, 1 skipped ✅
- TypeScript: 249 passed ✅