### PR TITLE
feat(mcp): add 8 missing tools (get, update, context, search, consolidate, stats, namespaces, suggested)

### DIFF
--- a/mcp-server/src/tools.test.ts
+++ b/mcp-server/src/tools.test.ts
@@ -11,6 +11,14 @@ function createMockClient(): MemoClawClientInterface {
     delete: vi.fn(),
     ingest: vi.fn(),
     status: vi.fn(),
+    get: vi.fn(),
+    update: vi.fn(),
+    assembleContext: vi.fn(),
+    textSearch: vi.fn(),
+    consolidate: vi.fn(),
+    stats: vi.fn(),
+    listNamespaces: vi.fn(),
+    suggested: vi.fn(),
   };
 }
 
@@ -35,15 +43,23 @@ describe('registerTools', () => {
     registerTools(server, client);
   });
 
-  it('registers all 6 tools', () => {
+  it('registers all 14 tools', () => {
     const tools = getRegisteredTools(server);
-    expect(Object.keys(tools).length).toBe(6);
+    expect(Object.keys(tools).length).toBe(14);
     expect(tools['memoclaw_store']).toBeDefined();
     expect(tools['memoclaw_recall']).toBeDefined();
     expect(tools['memoclaw_list']).toBeDefined();
     expect(tools['memoclaw_delete']).toBeDefined();
     expect(tools['memoclaw_ingest']).toBeDefined();
     expect(tools['memoclaw_status']).toBeDefined();
+    expect(tools['memoclaw_get']).toBeDefined();
+    expect(tools['memoclaw_update']).toBeDefined();
+    expect(tools['memoclaw_context']).toBeDefined();
+    expect(tools['memoclaw_search']).toBeDefined();
+    expect(tools['memoclaw_consolidate']).toBeDefined();
+    expect(tools['memoclaw_stats']).toBeDefined();
+    expect(tools['memoclaw_namespaces']).toBeDefined();
+    expect(tools['memoclaw_suggested']).toBeDefined();
   });
 
   describe('memoclaw_store', () => {
@@ -247,6 +263,262 @@ describe('registerTools', () => {
       expect(parsed.free_tier_remaining).toBe(85);
     });
   });
+
+  describe('memoclaw_get', () => {
+    it('calls client.get with id', async () => {
+      const memory = {
+        id: 'mem-1',
+        content: 'Test memory',
+        importance: 0.8,
+        memory_type: 'general',
+        namespace: 'default',
+        metadata: { tags: ['test'] },
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        accessed_at: '2026-01-02T00:00:00Z',
+        access_count: 5,
+        pinned: false,
+        immutable: false,
+        session_id: null,
+        agent_id: null,
+        expires_at: null,
+      };
+      (client.get as any).mockResolvedValue(memory);
+
+      const tools = getRegisteredTools(server);
+      const result = await tools['memoclaw_get'].handler({ id: 'mem-1' }, {} as any);
+
+      expect(client.get).toHaveBeenCalledWith('mem-1');
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.id).toBe('mem-1');
+      expect(parsed.content).toBe('Test memory');
+    });
+
+    it('handles not found errors', async () => {
+      (client.get as any).mockRejectedValue(new Error('Memory not found'));
+
+      const tools = getRegisteredTools(server);
+      const result = await tools['memoclaw_get'].handler({ id: 'nonexistent' }, {} as any);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Memory not found');
+    });
+  });
+
+  describe('memoclaw_update', () => {
+    it('calls client.update with id and fields', async () => {
+      const updated = {
+        id: 'mem-1',
+        content: 'Updated content',
+        importance: 0.9,
+        memory_type: 'preference',
+        namespace: 'default',
+        metadata: { tags: ['updated'] },
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z',
+        pinned: true,
+        immutable: false,
+      };
+      (client.update as any).mockResolvedValue(updated);
+
+      const tools = getRegisteredTools(server);
+      const result = await tools['memoclaw_update'].handler({
+        id: 'mem-1',
+        content: 'Updated content',
+        importance: 0.9,
+        pinned: true,
+        tags: ['updated'],
+      }, {} as any);
+
+      expect(client.update).toHaveBeenCalledWith('mem-1', {
+        content: 'Updated content',
+        importance: 0.9,
+        pinned: true,
+        metadata: { tags: ['updated'] },
+      });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.content).toBe('Updated content');
+    });
+  });
+
+  describe('memoclaw_context', () => {
+    it('calls client.assembleContext and returns text format', async () => {
+      (client.assembleContext as any).mockResolvedValue({
+        context: 'User prefers dark mode.\nUser uses TypeScript.',
+        memories_used: 2,
+        tokens: 15,
+      });
+
+      const tools = getRegisteredTools(server);
+      const result = await tools['memoclaw_context'].handler({
+        query: 'user preferences',
+        max_memories: 5,
+      }, {} as any);
+
+      expect(client.assembleContext).toHaveBeenCalledWith({
+        query: 'user preferences',
+        max_memories: 5,
+      });
+      expect(result.content[0].text).toContain('User prefers dark mode');
+      expect(result.content[0].text).toContain('Memories used: 2');
+    });
+
+    it('returns structured format as JSON', async () => {
+      const structured = { memories: [{ content: 'test' }] };
+      (client.assembleContext as any).mockResolvedValue({
+        context: structured,
+        memories_used: 1,
+        tokens: 5,
+      });
+
+      const tools = getRegisteredTools(server);
+      const result = await tools['memoclaw_context'].handler({
+        query: 'test',
+        format: 'structured',
+      }, {} as any);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.context).toEqual(structured);
+    });
+  });
+
+  describe('memoclaw_search', () => {
+    it('calls client.textSearch with params', async () => {
+      (client.textSearch as any).mockResolvedValue({
+        memories: [{
+          id: 'mem-1',
+          content: 'Dark mode preference',
+          importance: 0.8,
+          memory_type: 'preference',
+          namespace: 'default',
+          metadata: { tags: ['ui'] },
+          created_at: '2026-01-01T00:00:00Z',
+        }],
+        total: 1,
+      });
+
+      const tools = getRegisteredTools(server);
+      const result = await tools['memoclaw_search'].handler({
+        query: 'dark mode',
+        limit: 10,
+        namespace: 'default',
+      }, {} as any);
+
+      expect(client.textSearch).toHaveBeenCalledWith({
+        query: 'dark mode',
+        limit: 10,
+        namespace: 'default',
+      });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.memories).toHaveLength(1);
+      expect(parsed.total).toBe(1);
+    });
+  });
+
+  describe('memoclaw_consolidate', () => {
+    it('calls client.consolidate with dry_run', async () => {
+      (client.consolidate as any).mockResolvedValue({
+        clusters_found: 2,
+        memories_merged: 0,
+        memories_created: 0,
+        clusters: [
+          { memory_ids: ['mem-1', 'mem-2'], similarity: 0.95 },
+          { memory_ids: ['mem-3', 'mem-4'], similarity: 0.92 },
+        ],
+      });
+
+      const tools = getRegisteredTools(server);
+      const result = await tools['memoclaw_consolidate'].handler({
+        dry_run: true,
+        min_similarity: 0.9,
+      }, {} as any);
+
+      expect(client.consolidate).toHaveBeenCalledWith({
+        dry_run: true,
+        min_similarity: 0.9,
+      });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.clusters_found).toBe(2);
+    });
+  });
+
+  describe('memoclaw_stats', () => {
+    it('calls client.stats', async () => {
+      (client.stats as any).mockResolvedValue({
+        total_memories: 150,
+        pinned_count: 5,
+        never_accessed: 20,
+        total_accesses: 500,
+        avg_importance: 0.65,
+        oldest_memory: '2025-01-01T00:00:00Z',
+        newest_memory: '2026-03-09T00:00:00Z',
+        by_type: [{ memory_type: 'general', count: 100 }],
+        by_namespace: [{ namespace: 'default', count: 150 }],
+      });
+
+      const tools = getRegisteredTools(server);
+      const result = await tools['memoclaw_stats'].handler({}, {} as any);
+
+      expect(client.stats).toHaveBeenCalled();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.total_memories).toBe(150);
+    });
+  });
+
+  describe('memoclaw_namespaces', () => {
+    it('calls client.listNamespaces', async () => {
+      (client.listNamespaces as any).mockResolvedValue({
+        namespaces: [
+          { name: 'default', count: 100, last_memory_at: '2026-03-09T00:00:00Z' },
+          { name: 'prefs', count: 25, last_memory_at: '2026-03-08T00:00:00Z' },
+        ],
+        total: 2,
+      });
+
+      const tools = getRegisteredTools(server);
+      const result = await tools['memoclaw_namespaces'].handler({}, {} as any);
+
+      expect(client.listNamespaces).toHaveBeenCalled();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.namespaces).toHaveLength(2);
+      expect(parsed.total).toBe(2);
+    });
+  });
+
+  describe('memoclaw_suggested', () => {
+    it('calls client.suggested with filters', async () => {
+      (client.suggested as any).mockResolvedValue({
+        suggested: [{
+          id: 'mem-1',
+          content: 'Stale memory',
+          importance: 0.3,
+          memory_type: 'general',
+          namespace: 'default',
+          category: 'stale',
+          review_score: 0.85,
+          created_at: '2025-01-01T00:00:00Z',
+          accessed_at: '2025-01-15T00:00:00Z',
+          access_count: 1,
+        }],
+        categories: { stale: 1 },
+        total: 1,
+      });
+
+      const tools = getRegisteredTools(server);
+      const result = await tools['memoclaw_suggested'].handler({
+        category: 'stale',
+        limit: 10,
+      }, {} as any);
+
+      expect(client.suggested).toHaveBeenCalledWith({
+        category: 'stale',
+        limit: 10,
+      });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.suggested).toHaveLength(1);
+      expect(parsed.suggested[0].category).toBe('stale');
+    });
+  });
 });
 
 describe('createServer', () => {
@@ -256,6 +528,6 @@ describe('createServer', () => {
     const server = createServer(client);
 
     const tools = getRegisteredTools(server);
-    expect(Object.keys(tools).length).toBe(6);
+    expect(Object.keys(tools).length).toBe(14);
   });
 });

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -247,4 +247,284 @@ export function registerTools(server: McpServer, client: MemoClawClientInterface
       }
     },
   );
+
+  // ── memoclaw_get ────────────────────────────────────────────────────
+  server.tool(
+    'memoclaw_get',
+    'Get a single memory by its ID. Returns full memory details including metadata, access count, and timestamps.',
+    {
+      id: z.string().describe('Memory ID to retrieve'),
+    },
+    async ({ id }) => {
+      try {
+        const result = await client.get(id);
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      } catch (error: unknown) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ── memoclaw_update ─────────────────────────────────────────────────
+  server.tool(
+    'memoclaw_update',
+    'Update an existing memory. Can modify content, importance, tags, namespace, memory type, pinned/immutable status, and expiration.',
+    {
+      id: z.string().describe('Memory ID to update'),
+      content: z.string().optional().describe('New content for the memory'),
+      importance: z.number().min(0).max(1).optional().describe('New importance score'),
+      tags: z.array(z.string()).optional().describe('New tags (replaces existing)'),
+      namespace: z.string().optional().describe('New namespace'),
+      memory_type: MEMORY_TYPE_ENUM.optional().describe('New memory type'),
+      pinned: z.boolean().optional().describe('Pin or unpin the memory'),
+      immutable: z.boolean().optional().describe('Lock or unlock the memory'),
+      expires_at: z.string().optional().describe('New expiration timestamp (ISO 8601), or null to remove'),
+    },
+    async ({ id, content, importance, tags, namespace, memory_type, pinned, immutable, expires_at }) => {
+      try {
+        const request: Record<string, unknown> = {};
+        if (content !== undefined) request.content = content;
+        if (importance !== undefined) request.importance = importance;
+        if (namespace) request.namespace = namespace;
+        if (memory_type) request.memory_type = memory_type;
+        if (pinned !== undefined) request.pinned = pinned;
+        if (immutable !== undefined) request.immutable = immutable;
+        if (expires_at !== undefined) request.expires_at = expires_at;
+        if (tags !== undefined) request.metadata = { tags };
+
+        const result = await client.update(id, request);
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      } catch (error: unknown) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ── memoclaw_context ────────────────────────────────────────────────
+  server.tool(
+    'memoclaw_context',
+    'Assemble a context block from relevant memories for use in prompts. Returns formatted text or structured data with the most relevant memories for a given query.',
+    {
+      query: z.string().describe('Query to find relevant memories for context'),
+      namespace: z.string().optional().describe('Filter by namespace'),
+      session_id: z.string().optional().describe('Filter by session'),
+      agent_id: z.string().optional().describe('Filter by agent'),
+      max_memories: z.number().int().min(1).max(50).optional().describe('Maximum memories to include (default: 10)'),
+      max_tokens: z.number().int().min(100).optional().describe('Maximum tokens in context block'),
+      format: z.enum(['text', 'structured']).optional().describe('Output format (default: text)'),
+      include_metadata: z.boolean().optional().describe('Include metadata in output'),
+      summarize: z.boolean().optional().describe('Summarize memories for more compact context'),
+    },
+    async ({ query, namespace, session_id, agent_id, max_memories, max_tokens, format, include_metadata, summarize }) => {
+      try {
+        const request: Record<string, unknown> = { query };
+        if (namespace) request.namespace = namespace;
+        if (session_id) request.session_id = session_id;
+        if (agent_id) request.agent_id = agent_id;
+        if (max_memories !== undefined) request.max_memories = max_memories;
+        if (max_tokens !== undefined) request.max_tokens = max_tokens;
+        if (format) request.format = format;
+        if (include_metadata !== undefined) request.include_metadata = include_metadata;
+        if (summarize !== undefined) request.summarize = summarize;
+
+        const result = await client.assembleContext(request);
+        return {
+          content: [{
+            type: 'text' as const,
+            text: typeof result.context === 'string'
+              ? `${result.context}\n\n---\nMemories used: ${result.memories_used} | Tokens: ${result.tokens}`
+              : JSON.stringify(result, null, 2),
+          }],
+        };
+      } catch (error: unknown) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ── memoclaw_search ─────────────────────────────────────────────────
+  server.tool(
+    'memoclaw_search',
+    'Full-text keyword search across memories. Complementary to semantic recall — use for exact matches, specific terms, or when you know the exact phrasing.',
+    {
+      query: z.string().describe('Search query (keyword-based)'),
+      limit: z.number().int().min(1).max(50).optional().describe('Max results (default: 10)'),
+      namespace: z.string().optional().describe('Filter by namespace'),
+      tags: z.array(z.string()).optional().describe('Filter by tags'),
+      memory_type: MEMORY_TYPE_ENUM.optional().describe('Filter by memory type'),
+      session_id: z.string().optional().describe('Filter by session'),
+      agent_id: z.string().optional().describe('Filter by agent'),
+      after: z.string().optional().describe('Only memories created after this ISO timestamp'),
+    },
+    async ({ query, limit, namespace, tags, memory_type, session_id, agent_id, after }) => {
+      try {
+        const params: Record<string, unknown> = { query };
+        if (limit !== undefined) params.limit = limit;
+        if (namespace) params.namespace = namespace;
+        if (tags?.length) params.tags = tags;
+        if (memory_type) params.memory_type = memory_type;
+        if (session_id) params.session_id = session_id;
+        if (agent_id) params.agent_id = agent_id;
+        if (after) params.after = after;
+
+        const result = await client.textSearch(params);
+        const memories = result.memories.map((m) => ({
+          id: m.id,
+          content: m.content,
+          importance: m.importance,
+          memory_type: m.memory_type,
+          namespace: m.namespace,
+          tags: (m.metadata as Record<string, unknown>)?.tags,
+          created_at: m.created_at,
+        }));
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({ memories, total: result.total }, null, 2),
+          }],
+        };
+      } catch (error: unknown) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ── memoclaw_consolidate ────────────────────────────────────────────
+  server.tool(
+    'memoclaw_consolidate',
+    'Find and merge duplicate or very similar memories. Use dry_run=true to preview what would be merged without making changes.',
+    {
+      namespace: z.string().optional().describe('Limit consolidation to a namespace'),
+      min_similarity: z.number().min(0).max(1).optional().describe('Minimum similarity to consider as duplicate (default: 0.9)'),
+      mode: z.string().optional().describe('Consolidation mode'),
+      dry_run: z.boolean().optional().describe('Preview only — do not actually merge (default: false)'),
+    },
+    async ({ namespace, min_similarity, mode, dry_run }) => {
+      try {
+        const request: Record<string, unknown> = {};
+        if (namespace) request.namespace = namespace;
+        if (min_similarity !== undefined) request.min_similarity = min_similarity;
+        if (mode) request.mode = mode;
+        if (dry_run !== undefined) request.dry_run = dry_run;
+
+        const result = await client.consolidate(request);
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      } catch (error: unknown) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ── memoclaw_stats ──────────────────────────────────────────────────
+  server.tool(
+    'memoclaw_stats',
+    'Get memory statistics: total count, breakdown by type and namespace, importance averages, access patterns.',
+    {},
+    async () => {
+      try {
+        const result = await client.stats();
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      } catch (error: unknown) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ── memoclaw_namespaces ─────────────────────────────────────────────
+  server.tool(
+    'memoclaw_namespaces',
+    'List all namespaces with memory counts. Useful for understanding how memories are organized.',
+    {},
+    async () => {
+      try {
+        const result = await client.listNamespaces();
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      } catch (error: unknown) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ── memoclaw_suggested ──────────────────────────────────────────────
+  server.tool(
+    'memoclaw_suggested',
+    'Get memories that may need review: stale memories, decaying importance, or frequently accessed hot memories.',
+    {
+      limit: z.number().int().min(1).max(50).optional().describe('Max results (default: 20)'),
+      namespace: z.string().optional().describe('Filter by namespace'),
+      session_id: z.string().optional().describe('Filter by session'),
+      agent_id: z.string().optional().describe('Filter by agent'),
+      category: z.enum(['stale', 'fresh', 'hot', 'decaying']).optional().describe('Filter by category'),
+    },
+    async ({ limit, namespace, session_id, agent_id, category }) => {
+      try {
+        const params: Record<string, unknown> = {};
+        if (limit !== undefined) params.limit = limit;
+        if (namespace) params.namespace = namespace;
+        if (session_id) params.session_id = session_id;
+        if (agent_id) params.agent_id = agent_id;
+        if (category) params.category = category;
+
+        const result = await client.suggested(params);
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      } catch (error: unknown) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
 }

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -61,4 +61,103 @@ export interface MemoClawClientInterface {
     free_tier_total: number;
     free_tier_used: number;
   }>;
+
+  get(id: string): Promise<{
+    id: string;
+    content: string;
+    importance: number;
+    memory_type: string;
+    namespace: string;
+    metadata: Record<string, unknown>;
+    created_at: string;
+    updated_at: string;
+    accessed_at: string;
+    access_count: number;
+    pinned: boolean;
+    immutable: boolean;
+    session_id: string | null;
+    agent_id: string | null;
+    expires_at: string | null;
+  }>;
+
+  update(id: string, request: Record<string, unknown>): Promise<{
+    id: string;
+    content: string;
+    importance: number;
+    memory_type: string;
+    namespace: string;
+    metadata: Record<string, unknown>;
+    created_at: string;
+    updated_at: string;
+    pinned: boolean;
+    immutable: boolean;
+  }>;
+
+  assembleContext(request: Record<string, unknown>): Promise<{
+    context: string | Record<string, unknown>;
+    memories_used: number;
+    tokens: number;
+  }>;
+
+  textSearch(params: Record<string, unknown>): Promise<{
+    memories: Array<{
+      id: string;
+      content: string;
+      importance: number;
+      memory_type: string;
+      namespace: string;
+      metadata: Record<string, unknown>;
+      created_at: string;
+    }>;
+    total: number;
+  }>;
+
+  consolidate(request?: Record<string, unknown>): Promise<{
+    clusters_found: number;
+    memories_merged: number;
+    memories_created: number;
+    clusters: Array<{
+      memory_ids: string[];
+      similarity: number;
+      merged_into?: string;
+    }>;
+  }>;
+
+  stats(): Promise<{
+    total_memories: number;
+    pinned_count: number;
+    never_accessed: number;
+    total_accesses: number;
+    avg_importance: number;
+    oldest_memory: string | null;
+    newest_memory: string | null;
+    by_type: Array<{ memory_type: string; count: number }>;
+    by_namespace: Array<{ namespace: string; count: number }>;
+  }>;
+
+  listNamespaces(): Promise<{
+    namespaces: Array<{
+      name: string;
+      count: number;
+      last_memory_at: string | null;
+    }>;
+    total: number;
+  }>;
+
+  suggested(params?: Record<string, unknown>): Promise<{
+    suggested: Array<{
+      id: string;
+      content: string;
+      importance: number;
+      memory_type: string;
+      namespace: string;
+      category: string;
+      review_score: number;
+      created_at: string;
+      accessed_at: string;
+      access_count: number;
+    }>;
+    categories: Record<string, number>;
+    total: number;
+  }>;
 }


### PR DESCRIPTION
## Summary

Expands the MCP server from 6 to 14 tools, covering the most commonly needed SDK endpoints for agent workflows.

Fixes #153

## New Tools

| Tool | Description |
|------|-------------|
| `memoclaw_get` | Retrieve a single memory by ID |
| `memoclaw_update` | Modify existing memories (content, importance, tags, etc.) |
| `memoclaw_context` | Assemble context blocks from relevant memories for prompts |
| `memoclaw_search` | Full-text keyword search (complementary to semantic recall) |
| `memoclaw_consolidate` | Find and merge duplicate memories (supports dry_run) |
| `memoclaw_stats` | View memory statistics and breakdowns |
| `memoclaw_namespaces` | List all namespaces with counts |
| `memoclaw_suggested` | Get memories needing review (stale, decaying, hot) |

## Changes

- **mcp-server/src/types.ts** — Extended `MemoClawClientInterface` with 8 new method signatures
- **mcp-server/src/tools.ts** — Added 8 new tool registrations with zod schemas and error handling
- **mcp-server/src/tools.test.ts** — Full test coverage for all new tools (21 tests total, all passing)

## Tests

All existing and new tests pass:
- MCP server: 21/21 ✅
- TypeScript SDK: 249/249 ✅
- Python SDK: 424/424 ✅