### PR TITLE
fix: RecallBuilder output, delete_namespace return type, User-Agent header, deleteRelation auth

### DIFF
--- a/python/src/memoclaw/_client.py
+++ b/python/src/memoclaw/_client.py
@@ -84,6 +84,14 @@ DEFAULT_BASE_URL = "https://api.memoclaw.com"
 DEFAULT_TIMEOUT = 30.0
 DEFAULT_MAX_RETRIES = 2
 
+def _sdk_user_agent() -> str:
+    """Build User-Agent string with SDK version."""
+    try:
+        from . import __version__
+        return f"memoclaw-sdk-python/{__version__}"
+    except Exception:
+        return "memoclaw-sdk-python/unknown"
+
 # Default connection pool limits
 DEFAULT_POOL_MAX_CONNECTIONS = 10
 DEFAULT_POOL_MAX_KEEPALIVE_CONNECTIONS = 5
@@ -166,6 +174,7 @@ class _SyncHTTPClient:
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
         self._max_retries = max_retries
+        self._user_agent = _sdk_user_agent()
         
         # Configure connection pool limits for better performance
         limits = httpx.Limits(
@@ -193,9 +202,9 @@ class _SyncHTTPClient:
         for attempt in range(self._max_retries + 1):
             # Generate fresh auth header each attempt (timestamp-based)
             if self._account is not None:
-                headers = {"x-wallet-auth": _generate_wallet_auth(self._account)}
+                headers = {"x-wallet-auth": _generate_wallet_auth(self._account), "user-agent": self._user_agent}
             else:
-                headers = {"x-wallet-auth": _generate_wallet_only_auth(self._wallet_address)}
+                headers = {"x-wallet-auth": _generate_wallet_only_auth(self._wallet_address), "user-agent": self._user_agent}
 
             try:
                 response = self._http.request(
@@ -301,6 +310,7 @@ class _AsyncHTTPClient:
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
         self._max_retries = max_retries
+        self._user_agent = _sdk_user_agent()
         
         # Configure connection pool limits for better performance
         limits = httpx.Limits(
@@ -329,9 +339,9 @@ class _AsyncHTTPClient:
 
         for attempt in range(self._max_retries + 1):
             if self._account is not None:
-                headers = {"x-wallet-auth": _generate_wallet_auth(self._account)}
+                headers = {"x-wallet-auth": _generate_wallet_auth(self._account), "user-agent": self._user_agent}
             else:
-                headers = {"x-wallet-auth": _generate_wallet_only_auth(self._wallet_address)}
+                headers = {"x-wallet-auth": _generate_wallet_only_auth(self._wallet_address), "user-agent": self._user_agent}
 
             try:
                 response = await self._http.request(

--- a/python/src/memoclaw/builders.py
+++ b/python/src/memoclaw/builders.py
@@ -234,7 +234,11 @@ class RecallBuilder:
         return self
 
     def build(self) -> dict[str, Any]:
-        """Build the recall parameters dict."""
+        """Build recall parameters compatible with ``client.recall(**builder.build())``.
+
+        Returns a flat dict whose keys match the :meth:`MemoClaw.recall` /
+        :meth:`AsyncMemoClaw.recall` keyword arguments.
+        """
         if not self._query:
             raise ValueError("query is required")
         
@@ -252,16 +256,12 @@ class RecallBuilder:
             params["agent_id"] = self._agent_id
         if self._include_relations is not None:
             params["include_relations"] = self._include_relations
-        
-        if self._tags is not None or self._memory_type is not None or self._after is not None:
-            filters: dict[str, Any] = {}
-            if self._tags is not None:
-                filters["tags"] = self._tags
-            if self._memory_type is not None:
-                filters["memory_type"] = self._memory_type
-            if self._after is not None:
-                filters["after"] = self._after
-            params["filters"] = filters
+        if self._tags is not None:
+            params["tags"] = self._tags
+        if self._memory_type is not None:
+            params["memory_type"] = self._memory_type
+        if self._after is not None:
+            params["after"] = self._after
         
         return params
 

--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -34,6 +34,7 @@ from .types import (
     PinCoreMemoryResult,
     UnpinCoreMemoryResult,
     DeleteBatchItemResult,
+    DeleteNamespaceResult,
     DeleteResult,
     ExportResponse,
     ExtractResult,
@@ -877,6 +878,7 @@ class MemoClaw:
         Args:
             timeout: Per-request timeout in seconds. Overrides the client default.
         """
+        self._require_signed_auth("delete_relation")
         _validate_non_empty(memory_id, "memory_id")
         _validate_non_empty(relation_id, "relation_id")
         data = self._run_request(
@@ -1304,7 +1306,7 @@ class MemoClaw:
         *,
         batch_size: int = 50,
         timeout: float | None = None,
-    ) -> DeleteResult:
+    ) -> DeleteNamespaceResult:
         """Delete all memories in a namespace.
 
         Iterates through all memories in the given namespace and deletes
@@ -1318,7 +1320,7 @@ class MemoClaw:
         Example::
 
             result = client.delete_namespace("test-data")
-            print(f"Deleted {result.id} memories")  # id holds the count as string
+            print(f"Deleted {result.deleted_count} memories")
         """
         _validate_non_empty(namespace, "namespace")
         _validate_batch_size(batch_size)
@@ -1330,7 +1332,7 @@ class MemoClaw:
             ids = [m.id for m in page.memories]
             self.delete_batch(ids, timeout=timeout)
             total_deleted += len(ids)
-        return DeleteResult(deleted=total_deleted > 0, id=str(total_deleted))
+        return DeleteNamespaceResult(deleted=total_deleted > 0, deleted_count=total_deleted)
 
     # ── Graph helpers ────────────────────────────────────────────────────
 
@@ -2106,6 +2108,7 @@ class AsyncMemoClaw:
         self, memory_id: str, relation_id: str, *, timeout: float | None = None
     ) -> DeleteResult:
         """Delete a memory relationship."""
+        self._require_signed_auth("delete_relation")
         _validate_non_empty(memory_id, "memory_id")
         _validate_non_empty(relation_id, "relation_id")
         data = await self._run_request(
@@ -2502,7 +2505,7 @@ class AsyncMemoClaw:
         *,
         batch_size: int = 50,
         timeout: float | None = None,
-    ) -> DeleteResult:
+    ) -> DeleteNamespaceResult:
         """Delete all memories in a namespace.
 
         Async version of :meth:`MemoClaw.delete_namespace`.
@@ -2517,7 +2520,7 @@ class AsyncMemoClaw:
             ids = [m.id for m in page.memories]
             await self.delete_batch(ids, timeout=timeout)
             total_deleted += len(ids)
-        return DeleteResult(deleted=total_deleted > 0, id=str(total_deleted))
+        return DeleteNamespaceResult(deleted=total_deleted > 0, deleted_count=total_deleted)
 
     # ── Graph helpers ────────────────────────────────────────────────────
 

--- a/python/tests/test_builders.py
+++ b/python/tests/test_builders.py
@@ -133,7 +133,7 @@ class TestRecallBuilder:
             .build()
         )
         
-        assert params["filters"]["tags"] == ["tag1", "tag2"]
+        assert params["tags"] == ["tag1", "tag2"]
 
     def test_recall_with_memory_type(self):
         params = (
@@ -143,7 +143,7 @@ class TestRecallBuilder:
             .build()
         )
         
-        assert params["filters"]["memory_type"] == "preference"
+        assert params["memory_type"] == "preference"
 
     def test_recall_requires_query(self):
         with pytest.raises(ValueError, match="query is required"):
@@ -627,7 +627,7 @@ class TestStoreBuilder:
 class TestRecallBuilderAfter:
     """Test that RecallBuilder supports the after() filter."""
 
-    def test_after_included_in_filters(self):
+    def test_after_included_in_params(self):
         params = (
             RecallBuilder()
             .query("test query")
@@ -635,8 +635,7 @@ class TestRecallBuilderAfter:
             .build()
         )
         assert params["query"] == "test query"
-        assert "filters" in params
-        assert params["filters"]["after"] == "2026-01-01T00:00:00Z"
+        assert params["after"] == "2026-01-01T00:00:00Z"
 
     def test_after_combined_with_other_filters(self):
         params = (
@@ -647,10 +646,9 @@ class TestRecallBuilderAfter:
             .after("2026-03-01T00:00:00Z")
             .build()
         )
-        filters = params["filters"]
-        assert filters["tags"] == ["important"]
-        assert filters["memory_type"] == "preference"
-        assert filters["after"] == "2026-03-01T00:00:00Z"
+        assert params["tags"] == ["important"]
+        assert params["memory_type"] == "preference"
+        assert params["after"] == "2026-03-01T00:00:00Z"
 
     def test_after_only_filter(self):
         params = (
@@ -659,11 +657,13 @@ class TestRecallBuilderAfter:
             .after("2026-01-01T00:00:00Z")
             .build()
         )
-        assert params["filters"] == {"after": "2026-01-01T00:00:00Z"}
+        assert params["after"] == "2026-01-01T00:00:00Z"
 
-    def test_no_filters_when_none_set(self):
+    def test_no_extra_keys_when_none_set(self):
         params = RecallBuilder().query("test").build()
-        assert "filters" not in params
+        assert "tags" not in params
+        assert "memory_type" not in params
+        assert "after" not in params
 
 
 class TestAsyncRelationBuilder:

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -62,6 +62,7 @@ import {
 } from './errors.js';
 import { loadConfig } from './config.js';
 import { StoreBuilder } from './builders.js';
+import { VERSION } from './version.js';
 import { privateKeyToAccount, type PrivateKeyAccount } from 'viem/accounts';
 import type { Hex } from 'viem';
 
@@ -333,7 +334,9 @@ export class MemoClawClient {
     }
 
     // Generate auth header — signed if private key is available, plain wallet otherwise
-    const headers: Record<string, string> = {};
+    const headers: Record<string, string> = {
+      'user-agent': `memoclaw-sdk-ts/${VERSION}`,
+    };
     if (this._account) {
       const timestamp = Math.floor(Date.now() / 1000).toString();
       const authMessage = `memoclaw-auth:${timestamp}`;
@@ -730,6 +733,7 @@ export class MemoClawClient {
 
   /** Delete a relationship. */
   async deleteRelation(memoryId: string, relationId: string, options?: RequestOptions): Promise<DeleteRelationResponse> {
+    this.requireSignedAuth('deleteRelation');
     if (!memoryId?.trim()) throw new Error('memoryId must be a non-empty string');
     if (!relationId?.trim()) throw new Error('relationId must be a non-empty string');
     return this.request<DeleteRelationResponse>(


### PR DESCRIPTION
## Summary

Fixes 4 issues found during SDK audit:

### Bug Fixes
- **#157**: Python `RecallBuilder.build()` now returns flat kwargs compatible with `client.recall(**builder.build())` instead of nesting `tags`/`after`/`memory_type` inside a `filters` dict that would cause a `TypeError`
- **#158**: Python `delete_namespace()` returns `DeleteNamespaceResult` with proper `deleted_count: int` field instead of misusing `DeleteResult.id` as a count string
- **#160**: Added `requireSignedAuth` / `_require_signed_auth` check to `deleteRelation()` in both TS and Python SDKs for consistency with `createRelation()`

### Enhancements
- **#159**: Added `User-Agent` header (`memoclaw-sdk-python/X.Y.Z` / `memoclaw-sdk-ts/X.Y.Z`) to all HTTP requests for API-side debugging and SDK version tracking

### Tests
- All 426 Python tests pass ✅
- All 267 TypeScript tests pass ✅
- Updated RecallBuilder tests to match new flat output format

Fixes #157, Fixes #158, Fixes #159, Fixes #160