### PR TITLE
fix: Python SDK retry on PoolTimeout and fix SuggestedMemory type parity

### DIFF
--- a/python/src/memoclaw/_client.py
+++ b/python/src/memoclaw/_client.py
@@ -211,7 +211,7 @@ class _SyncHTTPClient:
                     method, url, headers=headers, json=json, params=params,
                     timeout=req_timeout,
                 )
-            except (httpx.ConnectError, httpx.ReadTimeout, httpx.WriteTimeout) as exc:
+            except (httpx.ConnectError, httpx.ReadTimeout, httpx.WriteTimeout, httpx.PoolTimeout) as exc:
                 last_exc = exc
                 if attempt < self._max_retries:
                     delay = _RETRY_BASE_DELAY * (2**attempt)
@@ -348,7 +348,7 @@ class _AsyncHTTPClient:
                     method, url, headers=headers, json=json, params=params,
                     timeout=req_timeout,
                 )
-            except (httpx.ConnectError, httpx.ReadTimeout, httpx.WriteTimeout) as exc:
+            except (httpx.ConnectError, httpx.ReadTimeout, httpx.WriteTimeout, httpx.PoolTimeout) as exc:
                 last_exc = exc
                 if attempt < self._max_retries:
                     delay = _RETRY_BASE_DELAY * (2**attempt)

--- a/python/src/memoclaw/types.py
+++ b/python/src/memoclaw/types.py
@@ -29,7 +29,7 @@ class RelatedMemorySummary(BaseModel):
     id: str
     content: str
     importance: float
-    memory_type: str
+    memory_type: MemoryType
     namespace: str
 
 
@@ -209,7 +209,7 @@ class SuggestedMemory(BaseModel):
     content: str
     metadata: dict[str, Any] = Field(default_factory=dict)
     importance: float
-    memory_type: str
+    memory_type: MemoryType
     namespace: str
     session_id: str | None = None
     agent_id: str | None = None

--- a/python/tests/test_edge_cases.py
+++ b/python/tests/test_edge_cases.py
@@ -314,3 +314,60 @@ class TestConsolidateEdgeCases:
         result = client.consolidate()
         assert result.clusters_found == 0
         assert len(result.clusters) == 0
+
+
+class TestPoolTimeoutRetry:
+    """Verify that httpx.PoolTimeout is caught and retried like other transient errors."""
+
+    def test_pool_timeout_retried_sync(self, client: MemoClaw):
+        """PoolTimeout should be retried and succeed if the next attempt works."""
+        call_count = 0
+
+        def mock_request(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.PoolTimeout("Connection pool exhausted")
+            return httpx.Response(
+                200,
+                json={"memories": [], "query_tokens": 3},
+            )
+
+        with patch.object(client._http._http, "request", side_effect=mock_request):
+            result = client.recall("test query")
+            assert call_count == 2
+            assert result.query_tokens == 3
+
+    def test_pool_timeout_exhausts_retries_sync(self, client: MemoClaw):
+        """PoolTimeout that persists through all retries should raise."""
+        with patch.object(
+            client._http._http,
+            "request",
+            side_effect=httpx.PoolTimeout("Connection pool exhausted"),
+        ):
+            with pytest.raises(httpx.PoolTimeout):
+                client.recall("test query")
+
+    @pytest.mark.asyncio
+    async def test_pool_timeout_retried_async(self):
+        """Async client: PoolTimeout should be retried."""
+        call_count = 0
+        async_client = AsyncMemoClaw(private_key=TEST_PRIVATE_KEY, base_url=BASE_URL)
+
+        async def mock_request(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.PoolTimeout("Connection pool exhausted")
+            return httpx.Response(
+                200,
+                json={"memories": [], "query_tokens": 5},
+            )
+
+        try:
+            with patch.object(async_client._http._http, "request", side_effect=mock_request):
+                result = await async_client.recall("test query")
+                assert call_count == 2
+                assert result.query_tokens == 5
+        finally:
+            await async_client.close()


### PR DESCRIPTION
## Changes

### Bug Fixes

1. **Add `httpx.PoolTimeout` to retry exception handling** (Fixes #162)
   - Both sync and async HTTP clients now catch `httpx.PoolTimeout` alongside `ConnectError`, `ReadTimeout`, and `WriteTimeout`
   - Under high concurrency, connection pool exhaustion will now be retried with exponential backoff instead of crashing

2. **Fix `SuggestedMemory.memory_type` type annotation** (Fixes #163)
   - Changed from `str` to `MemoryType` literal type on `SuggestedMemory` and `RelatedMemorySummary` models
   - Now matches the TS SDK type safety where `memory_type: MemoryType` is used

### Tests

- Added 3 new tests for PoolTimeout retry behavior:
  - Sync client: PoolTimeout retried and succeeds on second attempt
  - Sync client: PoolTimeout exhausts all retries and raises
  - Async client: PoolTimeout retried and succeeds on second attempt

### Test Results

- Python: 467 passed (3 new), 5 warnings
- TypeScript: 267 passed (unchanged)