### PR TITLE
feat: add x402 automatic payment support to TS SDK

### DIFF
--- a/typescript/src/__tests__/x402-payment.test.ts
+++ b/typescript/src/__tests__/x402-payment.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MemoClawClient, PaymentRequiredError } from '../index.js';
+
+const BASE_URL = 'https://api.memoclaw.com';
+const TEST_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+function mockFetch(responses: Array<{ status: number; body?: unknown; ok?: boolean; headers?: Record<string, string> }>): typeof globalThis.fetch {
+  let callIndex = 0;
+  return vi.fn(async () => {
+    const resp = responses[callIndex] ?? responses[responses.length - 1]!;
+    callIndex++;
+    const rawHeaders = resp.headers ?? {};
+    const hdrs = new Map(Object.entries(rawHeaders).map(([k, v]) => [k.toLowerCase(), v]));
+    return {
+      ok: resp.ok ?? (resp.status >= 200 && resp.status < 300),
+      status: resp.status,
+      json: async () => resp.body,
+      headers: { get: (name: string) => hdrs.get(name.toLowerCase()) ?? null },
+    } as Response;
+  });
+}
+
+describe('x402 automatic payment', () => {
+  it('throws PaymentRequiredError on 402 when x402 is not installed', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 402,
+        body: { error: { code: 'PAYMENT_REQUIRED', message: 'Payment required' } },
+      },
+    ]);
+
+    const client = new MemoClawClient({
+      privateKey: TEST_PRIVATE_KEY,
+      baseUrl: BASE_URL,
+      fetch: fetchFn,
+      maxRetries: 0,
+    });
+
+    await expect(client.store({ content: 'test memory' })).rejects.toThrow(PaymentRequiredError);
+  });
+
+  it('throws PaymentRequiredError on 402 when enableX402 is false', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 402,
+        body: { error: { code: 'PAYMENT_REQUIRED', message: 'Payment required' } },
+      },
+    ]);
+
+    const client = new MemoClawClient({
+      privateKey: TEST_PRIVATE_KEY,
+      baseUrl: BASE_URL,
+      fetch: fetchFn,
+      maxRetries: 0,
+      enableX402: false,
+    });
+
+    await expect(client.store({ content: 'test memory' })).rejects.toThrow(PaymentRequiredError);
+  });
+
+  it('retries with payment headers when x402 payment succeeds', async () => {
+    // First call returns 402, second call (with payment headers) succeeds
+    const fetchFn = mockFetch([
+      {
+        status: 402,
+        body: { error: { code: 'PAYMENT_REQUIRED', message: 'Payment required' } },
+      },
+      {
+        status: 200,
+        ok: true,
+        body: { id: 'mem_123', content: 'test memory' },
+      },
+    ]);
+
+    // Mock the dynamic import of x402
+    const originalFunction = globalThis.Function;
+    const mockCreatePaymentHeaders = vi.fn().mockResolvedValue({
+      'x-payment': 'mock-payment-token',
+      'x-payment-chain': 'base',
+    });
+
+    // Override Function constructor to intercept the dynamic import
+    globalThis.Function = vi.fn().mockReturnValue(() =>
+      Promise.resolve({ createPaymentHeaders: mockCreatePaymentHeaders }),
+    ) as unknown as FunctionConstructor;
+
+    try {
+      const client = new MemoClawClient({
+        privateKey: TEST_PRIVATE_KEY,
+        baseUrl: BASE_URL,
+        fetch: fetchFn,
+        maxRetries: 0,
+        enableX402: true,
+      });
+
+      const result = await client.store({ content: 'test memory' });
+      expect(result).toEqual({ id: 'mem_123', content: 'test memory' });
+
+      // Verify fetch was called twice (initial + retry with payment headers)
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+
+      // Verify the second call includes payment headers
+      const secondCallArgs = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[1];
+      const secondCallHeaders = secondCallArgs?.[1]?.headers as Record<string, string>;
+      expect(secondCallHeaders).toMatchObject({
+        'x-payment': 'mock-payment-token',
+        'x-payment-chain': 'base',
+      });
+    } finally {
+      globalThis.Function = originalFunction;
+    }
+  });
+
+  it('falls through to error when x402 payment retry also fails', async () => {
+    // Both 402 responses
+    const fetchFn = mockFetch([
+      {
+        status: 402,
+        body: { error: { code: 'PAYMENT_REQUIRED', message: 'Payment required' } },
+      },
+      {
+        status: 402,
+        body: { error: { code: 'INSUFFICIENT_FUNDS', message: 'Insufficient funds after payment' } },
+      },
+    ]);
+
+    const originalFunction = globalThis.Function;
+    globalThis.Function = vi.fn().mockReturnValue(() =>
+      Promise.resolve({
+        createPaymentHeaders: vi.fn().mockResolvedValue({ 'x-payment': 'mock-token' }),
+      }),
+    ) as unknown as FunctionConstructor;
+
+    try {
+      const client = new MemoClawClient({
+        privateKey: TEST_PRIVATE_KEY,
+        baseUrl: BASE_URL,
+        fetch: fetchFn,
+        maxRetries: 0,
+        enableX402: true,
+      });
+
+      await expect(client.store({ content: 'test memory' })).rejects.toThrow(PaymentRequiredError);
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    } finally {
+      globalThis.Function = originalFunction;
+    }
+  });
+
+  it('falls through gracefully when x402 createPaymentHeaders throws', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 402,
+        body: { error: { code: 'PAYMENT_REQUIRED', message: 'Payment required' } },
+      },
+    ]);
+
+    const originalFunction = globalThis.Function;
+    globalThis.Function = vi.fn().mockReturnValue(() =>
+      Promise.resolve({
+        createPaymentHeaders: vi.fn().mockRejectedValue(new Error('Payment creation failed')),
+      }),
+    ) as unknown as FunctionConstructor;
+
+    try {
+      const client = new MemoClawClient({
+        privateKey: TEST_PRIVATE_KEY,
+        baseUrl: BASE_URL,
+        fetch: fetchFn,
+        maxRetries: 0,
+        enableX402: true,
+      });
+
+      await expect(client.store({ content: 'test memory' })).rejects.toThrow(PaymentRequiredError);
+      // Only one fetch call — no retry since payment header creation failed
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.Function = originalFunction;
+    }
+  });
+
+  it('enableX402 defaults to true', async () => {
+    // When x402 is not installed (dynamic import fails), it should still
+    // fall through to PaymentRequiredError gracefully
+    const fetchFn = mockFetch([
+      {
+        status: 402,
+        body: { error: { code: 'PAYMENT_REQUIRED', message: 'Payment required' } },
+      },
+    ]);
+
+    const client = new MemoClawClient({
+      privateKey: TEST_PRIVATE_KEY,
+      baseUrl: BASE_URL,
+      fetch: fetchFn,
+      maxRetries: 0,
+      // enableX402 not set — should default to true
+    });
+
+    // x402 is not installed in test env, so it should fail gracefully
+    await expect(client.store({ content: 'test memory' })).rejects.toThrow(PaymentRequiredError);
+  });
+
+  it('runs after-response hooks on successful x402 retry', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 402,
+        body: { error: { code: 'PAYMENT_REQUIRED', message: 'Payment required' } },
+      },
+      {
+        status: 200,
+        ok: true,
+        body: { id: 'mem_456', content: 'hooked memory' },
+      },
+    ]);
+
+    const originalFunction = globalThis.Function;
+    globalThis.Function = vi.fn().mockReturnValue(() =>
+      Promise.resolve({
+        createPaymentHeaders: vi.fn().mockResolvedValue({ 'x-payment': 'mock-token' }),
+      }),
+    ) as unknown as FunctionConstructor;
+
+    const afterHook = vi.fn();
+
+    try {
+      const client = new MemoClawClient({
+        privateKey: TEST_PRIVATE_KEY,
+        baseUrl: BASE_URL,
+        fetch: fetchFn,
+        maxRetries: 0,
+        enableX402: true,
+      });
+      client.onAfterResponse(afterHook);
+
+      await client.store({ content: 'hooked memory' });
+      expect(afterHook).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.Function = originalFunction;
+    }
+  });
+});

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -205,6 +205,7 @@ export class MemoClawClient {
   private readonly maxRetries: number;
   private readonly retryDelay: number;
   private readonly timeout: number;
+  private readonly enableX402: boolean;
   private readonly _beforeRequestHooks: BeforeRequestHook[] = [];
   private readonly _afterResponseHooks: AfterResponseHook[] = [];
   private readonly _onErrorHooks: OnErrorHook[] = [];
@@ -248,6 +249,7 @@ export class MemoClawClient {
     this.maxRetries = options.maxRetries ?? 2;
     this.retryDelay = options.retryDelay ?? 500;
     this.timeout = options.timeout ?? 0;
+    this.enableX402 = options.enableX402 ?? true;
 
     // Logging: accepts a custom Logger, or `debug: true` for console output.
     // Wrap with level-gating and optional structured JSON formatting.
@@ -301,6 +303,27 @@ export class MemoClawClient {
   }
 
   // ── Internal helpers ───────────────────────────────
+
+  /**
+   * Attempt to create x402 payment headers from a 402 response.
+   * Returns payment headers on success, or null if x402 is unavailable.
+   * @internal
+   */
+  private async _tryX402Payment(response: Response): Promise<Record<string, string> | null> {
+    if (!this.enableX402) return null;
+    try {
+      // Dynamic import — only loaded if the user has installed x402
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const x402Module: any = await (Function('return import("x402")')() as Promise<any>);
+      const createPaymentHeaders = x402Module.createPaymentHeaders ?? x402Module.default?.createPaymentHeaders;
+      if (typeof createPaymentHeaders !== 'function') return null;
+      const paymentHeaders: Record<string, string> = await createPaymentHeaders(response);
+      return paymentHeaders;
+    } catch {
+      // x402 not installed or payment creation failed
+      return null;
+    }
+  }
 
   /** Throw if the client is in wallet-only mode (no private key). */
   private requireSignedAuth(method: string): void {
@@ -425,6 +448,33 @@ export class MemoClawClient {
           if (result !== undefined) data = result as T;
         }
         return data;
+      }
+
+      // 402 → attempt x402 automatic payment and retry once
+      if (res.status === 402) {
+        this._logger?.debug(`${method} ${path} → 402, attempting x402 payment`, { method, path });
+        const paymentHeaders = await this._tryX402Payment(res);
+        if (paymentHeaders) {
+          this._logger?.info(`x402 payment headers created, retrying ${method} ${path}`, { method, path });
+          // Retry the request with payment headers merged in
+          const retryHeaders = { ...headers, ...paymentHeaders };
+          const retryRes = await this._fetch(url, { method, headers: retryHeaders, body: jsonBody, signal: combinedSignal });
+          if (retryRes.ok) {
+            const duration = Date.now() - startTime;
+            const reqId = retryRes.headers?.get('x-request-id') ?? undefined;
+            this._logger?.info(`${method} ${path} → ${retryRes.status} (${duration}ms, x402 paid)`, reqId ? `req=${reqId}` : '', {
+              method, path, status: retryRes.status, duration_ms: duration, request_id: reqId,
+            });
+            let data = (await retryRes.json()) as T;
+            for (const hook of this._afterResponseHooks) {
+              const result = hook(method, path, data);
+              if (result !== undefined) data = result as T;
+            }
+            return data;
+          }
+          // x402 retry failed — fall through to normal error handling with the retry response
+          res = retryRes;
+        }
       }
 
       let errorBody: MemoClawErrorBody | undefined;

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -549,6 +549,12 @@ export interface MemoClawOptions {
   /** Log output format. `'text'` (default) for human-readable, `'json'` for
    *  structured JSON suitable for observability pipelines (Datadog, Grafana, etc). */
   logFormat?: LogFormat;
+  /** Enable automatic x402 payment on 402 responses. When true (default),
+   *  the SDK will attempt to dynamically import the `x402` package and
+   *  create payment headers to retry the request. If the package is not
+   *  installed, falls through to normal PaymentRequiredError handling.
+   *  Set to false to disable automatic payment attempts. */
+  enableX402?: boolean;
 }
 
 /** Supported log levels (ascending severity). `'none'` disables all output. */


### PR DESCRIPTION
## Summary

Adds automatic x402 payment support to the TypeScript SDK, bringing it to feature parity with the Python SDK.

## Changes

- **`typescript/src/client.ts`**: Added `_tryX402Payment()` helper and 402 handling in `request()` method. On 402 response, attempts dynamic import of the `x402` package, creates payment headers, and retries the request.
- **`typescript/src/types.ts`**: Added `enableX402` option to `MemoClawOptions` (defaults to `true`)
- **`typescript/src/__tests__/x402-payment.test.ts`**: 7 tests covering:
  - 402 fallthrough when x402 not installed
  - 402 fallthrough when enableX402 is false
  - Successful payment retry
  - Failed payment retry (second 402)
  - Graceful handling when createPaymentHeaders throws
  - Default enableX402 behavior
  - After-response hooks fire on successful x402 retry

## How it works

1. On 402 response, SDK attempts to dynamically import `x402`
2. If available, calls `createPaymentHeaders(response)` to get USDC payment headers
3. Retries the original request with payment headers merged in
4. If x402 is not installed or payment fails, falls through to `PaymentRequiredError`
5. Users can opt out with `enableX402: false`

## Testing

- All 274 TS tests pass (267 existing + 7 new)
- All 464 Python tests pass (no regressions)
- TypeScript compiles clean

Fixes #164