### PR TITLE
fix: correct endpoint URLs to match API documentation

### DIFF
--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -666,7 +666,7 @@ class MemoClaw:
             if "id" not in item or not item["id"]:
                 raise ValueError("Each update must include a non-empty 'id'")
         data = self._run_request(
-            "POST", "/v1/memories/batch-update", json={"updates": items}, timeout=timeout
+            "PATCH", "/v1/memories/batch", json={"updates": items}, timeout=timeout
         )
         return UpdateBatchResult.model_validate(data)
 
@@ -1100,7 +1100,7 @@ class MemoClaw:
         params = _clean_params(
             {"limit": limit, "namespace": namespace, "agent_id": agent_id}
         )
-        data = self._run_request("GET", "/v1/core-memories", params=params, timeout=timeout)
+        data = self._run_request("GET", "/v1/memories/core", params=params, timeout=timeout)
         return CoreMemoriesResponse.model_validate(data)
 
     def pin_core_memory(self, memory_id: str, *, timeout: float | None = None) -> PinCoreMemoryResult:
@@ -1154,9 +1154,9 @@ class MemoClaw:
         """
         _validate_non_empty(query, "query")
         _validate_limit(limit)
-        params = _clean_params(
+        body = _clean_body(
             {
-                "q": query,
+                "query": query,
                 "limit": limit,
                 "namespace": namespace,
                 "tags": tags,
@@ -1166,7 +1166,7 @@ class MemoClaw:
                 "after": after,
             }
         )
-        data = self._run_request("GET", "/v1/memories/search", params=params, timeout=timeout)
+        data = self._run_request("POST", "/v1/search", json=body, timeout=timeout)
         return TextSearchResponse.model_validate(data)
 
     # ── Export ────────────────────────────────────────────────────────────
@@ -1898,7 +1898,7 @@ class AsyncMemoClaw:
             if "id" not in item or not item["id"]:
                 raise ValueError("Each update must include a non-empty 'id'")
         data = await self._run_request(
-            "POST", "/v1/memories/batch-update", json={"updates": items}, timeout=timeout
+            "PATCH", "/v1/memories/batch", json={"updates": items}, timeout=timeout
         )
         return UpdateBatchResult.model_validate(data)
 
@@ -2302,7 +2302,7 @@ class AsyncMemoClaw:
         params = _clean_params(
             {"limit": limit, "namespace": namespace, "agent_id": agent_id}
         )
-        data = await self._run_request("GET", "/v1/core-memories", params=params, timeout=timeout)
+        data = await self._run_request("GET", "/v1/memories/core", params=params, timeout=timeout)
         return CoreMemoriesResponse.model_validate(data)
 
     async def pin_core_memory(self, memory_id: str, *, timeout: float | None = None) -> PinCoreMemoryResult:
@@ -2356,9 +2356,9 @@ class AsyncMemoClaw:
         """
         _validate_non_empty(query, "query")
         _validate_limit(limit)
-        params = _clean_params(
+        body = _clean_body(
             {
-                "q": query,
+                "query": query,
                 "limit": limit,
                 "namespace": namespace,
                 "tags": tags,
@@ -2368,7 +2368,7 @@ class AsyncMemoClaw:
                 "after": after,
             }
         )
-        data = await self._run_request("GET", "/v1/memories/search", params=params, timeout=timeout)
+        data = await self._run_request("POST", "/v1/search", json=body, timeout=timeout)
         return TextSearchResponse.model_validate(data)
 
     # ── Export ────────────────────────────────────────────────────────────

--- a/python/tests/test_async_client.py
+++ b/python/tests/test_async_client.py
@@ -497,7 +497,7 @@ class TestAsyncCoreMemories:
     @respx.mock
     @pytest.mark.asyncio
     async def test_core_memories(self, client: AsyncMemoClaw):
-        respx.get(f"{BASE_URL}/v1/core-memories").mock(
+        respx.get(f"{BASE_URL}/v1/memories/core").mock(
             return_value=httpx.Response(200, json={
                 "memories": [_MEM_JSON],
                 "total": 1,
@@ -512,7 +512,7 @@ class TestAsyncTextSearch:
     @respx.mock
     @pytest.mark.asyncio
     async def test_text_search(self, client: AsyncMemoClaw):
-        respx.get(f"{BASE_URL}/v1/memories/search").mock(
+        respx.post(f"{BASE_URL}/v1/search").mock(
             return_value=httpx.Response(200, json={
                 "memories": [_MEM_JSON],
                 "total": 1,
@@ -566,7 +566,7 @@ class TestAsyncUpdateBatch:
     @respx.mock
     @pytest.mark.asyncio
     async def test_update_batch(self, client: AsyncMemoClaw):
-        respx.post(f"{BASE_URL}/v1/memories/batch-update").mock(
+        respx.patch(f"{BASE_URL}/v1/memories/batch").mock(
             return_value=httpx.Response(200, json={
                 "updated": 2,
                 "failed": 0,

--- a/python/tests/test_new_endpoints.py
+++ b/python/tests/test_new_endpoints.py
@@ -250,7 +250,7 @@ class TestGetHistory:
 class TestUpdateBatch:
     @respx.mock
     def test_basic(self, client):
-        respx.post(f"{BASE_URL}/v1/memories/batch-update").mock(
+        respx.patch(f"{BASE_URL}/v1/memories/batch").mock(
             return_value=httpx.Response(200, json={
                 "results": [
                     {"id": "mem-1", "updated": True},
@@ -272,7 +272,7 @@ class TestUpdateBatch:
 
     @respx.mock
     def test_with_update_input(self, client):
-        respx.post(f"{BASE_URL}/v1/memories/batch-update").mock(
+        respx.patch(f"{BASE_URL}/v1/memories/batch").mock(
             return_value=httpx.Response(200, json={
                 "results": [{"id": "mem-1", "updated": True}],
                 "updated": 1,
@@ -301,7 +301,7 @@ class TestUpdateBatch:
     @respx.mock
     @pytest.mark.asyncio
     async def test_async(self, async_client):
-        respx.post(f"{BASE_URL}/v1/memories/batch-update").mock(
+        respx.patch(f"{BASE_URL}/v1/memories/batch").mock(
             return_value=httpx.Response(200, json={
                 "results": [{"id": "mem-1", "updated": True}],
                 "updated": 1,
@@ -319,7 +319,7 @@ class TestUpdateBatch:
 class TestCoreMemories:
     @respx.mock
     def test_sync(self, client):
-        respx.get(f"{BASE_URL}/v1/core-memories").mock(
+        respx.get(f"{BASE_URL}/v1/memories/core").mock(
             return_value=httpx.Response(200, json={
                 "memories": [{"id": "mem-1", "content": "core", "user_id": "u", "namespace": "default",
                     "embedding_model": "text-embedding-3-small", "metadata": {}, "importance": 0.9,
@@ -339,7 +339,7 @@ class TestCoreMemories:
     @respx.mock
     @pytest.mark.asyncio
     async def test_async(self, async_client):
-        respx.get(f"{BASE_URL}/v1/core-memories").mock(
+        respx.get(f"{BASE_URL}/v1/memories/core").mock(
             return_value=httpx.Response(200, json={
                 "memories": [],
                 "total": 0,
@@ -422,7 +422,7 @@ class TestUnpinCoreMemory:
 class TestTextSearch:
     @respx.mock
     def test_sync(self, client):
-        respx.get(f"{BASE_URL}/v1/memories/search").mock(
+        respx.post(f"{BASE_URL}/v1/search").mock(
             return_value=httpx.Response(200, json={
                 "memories": [{"id": "mem-1", "content": "hello world", "user_id": "u", "namespace": "default",
                     "embedding_model": "text-embedding-3-small", "metadata": {}, "importance": 0.5,
@@ -445,7 +445,7 @@ class TestTextSearch:
     @respx.mock
     @pytest.mark.asyncio
     async def test_async(self, async_client):
-        respx.get(f"{BASE_URL}/v1/memories/search").mock(
+        respx.post(f"{BASE_URL}/v1/search").mock(
             return_value=httpx.Response(200, json={
                 "memories": [],
                 "total": 0,

--- a/typescript/src/__tests__/new-endpoints.test.ts
+++ b/typescript/src/__tests__/new-endpoints.test.ts
@@ -164,7 +164,7 @@ describe('getHistory', () => {
 });
 
 describe('updateBatch', () => {
-  it('should POST /v1/memories/batch-update', async () => {
+  it('should PATCH /v1/memories/batch', async () => {
     const fetch = mockFetch([{
       status: 200,
       body: {
@@ -186,8 +186,8 @@ describe('updateBatch', () => {
     expect(result.failed).toBe(0);
     expect(result.results).toHaveLength(2);
     expect(fetch).toHaveBeenCalledWith(
-      `${BASE_URL}/v1/memories/batch-update`,
-      expect.objectContaining({ method: 'POST' }),
+      `${BASE_URL}/v1/memories/batch`,
+      expect.objectContaining({ method: 'PATCH' }),
     );
   });
 
@@ -209,14 +209,14 @@ describe('updateBatch', () => {
 });
 
 describe('coreMemories', () => {
-  it('should GET /v1/core-memories', async () => {
+  it('should GET /v1/memories/core', async () => {
     const body = { memories: [{ id: 'mem-1', content: 'core' }], total: 1 };
     const fetchFn = mockFetch([{ status: 200, body }]);
     const client = createClient(fetchFn);
     const result = await client.coreMemories();
     expect(result).toEqual(body);
     expect(fetchFn).toHaveBeenCalledWith(
-      `${BASE_URL}/v1/core-memories`,
+      `${BASE_URL}/v1/memories/core`,
       expect.objectContaining({ method: 'GET' }),
     );
   });
@@ -274,15 +274,15 @@ describe('unpinCoreMemory', () => {
 });
 
 describe('textSearch', () => {
-  it('should GET /v1/memories/search with query', async () => {
+  it('should POST /v1/search with query in body', async () => {
     const body = { memories: [{ id: 'mem-1', content: 'hello' }], total: 1 };
     const fetchFn = mockFetch([{ status: 200, body }]);
     const client = createClient(fetchFn);
     const result = await client.textSearch({ query: 'hello' });
     expect(result).toEqual(body);
     expect(fetchFn).toHaveBeenCalledWith(
-      expect.stringContaining('/v1/memories/search?q=hello'),
-      expect.objectContaining({ method: 'GET' }),
+      `${BASE_URL}/v1/search`,
+      expect.objectContaining({ method: 'POST' }),
     );
   });
 
@@ -302,12 +302,13 @@ describe('textSearch', () => {
       tags: ['a', 'b'],
       memory_type: 'correction',
     });
-    const url = (fetchFn as any).mock.calls[0][0] as string;
-    expect(url).toContain('q=test');
-    expect(url).toContain('limit=10');
-    expect(url).toContain('namespace=ns');
-    expect(url).toContain('tags=a%2Cb');
-    expect(url).toContain('memory_type=correction');
+    const callArgs = (fetchFn as any).mock.calls[0];
+    const requestBody = JSON.parse(callArgs[1].body);
+    expect(requestBody.query).toBe('test');
+    expect(requestBody.limit).toBe(10);
+    expect(requestBody.namespace).toBe('ns');
+    expect(requestBody.tags).toEqual(['a', 'b']);
+    expect(requestBody.memory_type).toBe('correction');
   });
 });
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -637,7 +637,7 @@ export class MemoClawClient {
       }
     }
     return this.request<UpdateBatchResponse>(
-      'POST', '/v1/memories/batch-update',
+      'PATCH', '/v1/memories/batch',
       { updates } satisfies UpdateBatchRequest,
       undefined, options,
     );
@@ -958,7 +958,7 @@ export class MemoClawClient {
     if (params.limit !== undefined) query['limit'] = String(params.limit);
     if (params.namespace) query['namespace'] = params.namespace;
     if (params.agent_id) query['agent_id'] = params.agent_id;
-    return this.request<CoreMemoriesResponse>('GET', '/v1/core-memories', undefined, Object.keys(query).length ? query : undefined, options);
+    return this.request<CoreMemoriesResponse>('GET', '/v1/memories/core', undefined, Object.keys(query).length ? query : undefined, options);
   }
 
   /**
@@ -994,15 +994,15 @@ export class MemoClawClient {
       throw new Error('query must be a non-empty string');
     }
     validateLimit(params.limit);
-    const query: Record<string, string> = { q: params.query };
-    if (params.limit !== undefined) query['limit'] = String(params.limit);
-    if (params.namespace) query['namespace'] = params.namespace;
-    if (params.tags?.length) query['tags'] = params.tags.join(',');
-    if (params.memory_type) query['memory_type'] = params.memory_type;
-    if (params.session_id) query['session_id'] = params.session_id;
-    if (params.agent_id) query['agent_id'] = params.agent_id;
-    if (params.after) query['after'] = params.after;
-    return this.request<TextSearchResponse>('GET', '/v1/memories/search', undefined, query, options);
+    const body: Record<string, unknown> = { query: params.query };
+    if (params.limit !== undefined) body['limit'] = params.limit;
+    if (params.namespace) body['namespace'] = params.namespace;
+    if (params.tags?.length) body['tags'] = params.tags;
+    if (params.memory_type) body['memory_type'] = params.memory_type;
+    if (params.session_id) body['session_id'] = params.session_id;
+    if (params.agent_id) body['agent_id'] = params.agent_id;
+    if (params.after) body['after'] = params.after;
+    return this.request<TextSearchResponse>('POST', '/v1/search', body, undefined, options);
   }
 
   // ── Export ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes three endpoint URL mismatches between the SDKs and the API documentation.

### Bug fixes

1. **Core memories** (#167): `GET /v1/core-memories` → `GET /v1/memories/core`
2. **Text search** (#168): `GET /v1/memories/search` (query params) → `POST /v1/search` (JSON body)
3. **Batch update** (#169): `POST /v1/memories/batch-update` → `PATCH /v1/memories/batch`

### Changes

- **Python SDK** (`client.py`): Fixed URLs and HTTP methods in both sync (`MemoClaw`) and async (`AsyncMemoClaw`) classes
- **TypeScript SDK** (`client.ts`): Fixed URLs and HTTP methods
- **Tests**: Updated all affected test cases in both SDKs to match the corrected endpoints

### Verification

- ✅ TypeScript: 274 tests pass (9 suites)
- ✅ Python: 429 tests pass

Fixes #167, Fixes #168, Fixes #169