### PR TITLE
fix: graph helper bugs and missing RequestOptions/timeout

### DIFF
--- a/examples/typescript/advanced_usage.ts
+++ b/examples/typescript/advanced_usage.ts
@@ -149,7 +149,7 @@ async function main() {
   const memoryId = result.id;
   
   // Get memory graph (relations up to N hops)
-  const graph = await client.getMemoryGraph(memoryId, depth=2);
+  const graph = await client.getMemoryGraph(memoryId, 2);
   console.log(`Graph has ${graph.size} nodes`);
   
   // Find related memories

--- a/examples/typescript/ai_assistant_example.ts
+++ b/examples/typescript/ai_assistant_example.ts
@@ -103,7 +103,7 @@ async function main() {
 
   // 6. Graph traversal
   console.log('\n6. Memory graph traversal...');
-  const graph = await client.getMemoryGraph(pref1.id, depth=2);
+  const graph = await client.getMemoryGraph(pref1.id, 2);
   console.log(`   Graph from "${pref1.id}":`);
   for (const [mid, relations] of graph) {
     console.log(`   - ${mid}: ${relations.length} relations`);

--- a/examples/typescript/graph_traversal.ts
+++ b/examples/typescript/graph_traversal.ts
@@ -78,7 +78,7 @@ async function main() {
   // Traverse the graph to depth 2
   console.log('\n4. Traversing graph to depth 2...\n');
 
-  const graph = await client.getMemoryGraph(mem1.id, depth=2);
+  const graph = await client.getMemoryGraph(mem1.id, 2);
   console.log(`Visited ${graph.size} nodes in the graph:`);
   
   for (const [memoryId, relations] of graph.entries()) {

--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -1341,10 +1341,16 @@ class MemoClaw:
         memory_id: str,
         *,
         depth: int = 1,
+        timeout: float | None = None,
     ) -> dict[str, _list[RelationWithMemory]]:
         """Traverse the memory graph from a starting node.
 
         Returns a dict mapping memory IDs to their relations, up to ``depth`` hops.
+
+        Args:
+            memory_id: Starting memory ID.
+            depth: Number of hops to traverse (default 1).
+            timeout: Per-request timeout in seconds. Overrides the client default.
 
         Example::
 
@@ -1360,7 +1366,7 @@ class MemoClaw:
             for mid in frontier:
                 if mid in visited:
                     continue
-                rels = self.list_relations(mid)
+                rels = self.list_relations(mid, timeout=timeout)
                 visited[mid] = rels
                 for rel in rels:
                     neighbor_id = rel.memory.id
@@ -1378,14 +1384,21 @@ class MemoClaw:
         *,
         relation_type: RelationType | None = None,
         direction: str | None = None,
+        timeout: float | None = None,
     ) -> _list[RelationWithMemory]:
         """Find relations for a memory, optionally filtered by type and direction.
+
+        Args:
+            memory_id: Memory ID to find relations for.
+            relation_type: Filter by relation type.
+            direction: Filter by direction (``"outgoing"`` or ``"incoming"``).
+            timeout: Per-request timeout in seconds. Overrides the client default.
 
         Example::
 
             contradictions = client.find_related("mem-123", relation_type="contradicts")
         """
-        rels = self.list_relations(memory_id)
+        rels = self.list_relations(memory_id, timeout=timeout)
         if relation_type is not None:
             rels = [r for r in rels if r.relation_type == relation_type]
         if direction is not None:
@@ -2529,8 +2542,17 @@ class AsyncMemoClaw:
         memory_id: str,
         *,
         depth: int = 1,
+        timeout: float | None = None,
     ) -> dict[str, _list[RelationWithMemory]]:
-        """Traverse the memory graph from a starting node. See sync version for details."""
+        """Traverse the memory graph from a starting node.
+
+        Async version of :meth:`MemoClaw.get_memory_graph`. See sync version for details.
+
+        Args:
+            memory_id: Starting memory ID.
+            depth: Number of hops to traverse (default 1).
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
         visited: dict[str, _list[RelationWithMemory]] = {}
         frontier = [memory_id]
 
@@ -2539,7 +2561,7 @@ class AsyncMemoClaw:
             for mid in frontier:
                 if mid in visited:
                     continue
-                rels = await self.list_relations(mid)
+                rels = await self.list_relations(mid, timeout=timeout)
                 visited[mid] = rels
                 for rel in rels:
                     neighbor_id = rel.memory.id
@@ -2557,9 +2579,19 @@ class AsyncMemoClaw:
         *,
         relation_type: RelationType | None = None,
         direction: str | None = None,
+        timeout: float | None = None,
     ) -> _list[RelationWithMemory]:
-        """Find relations for a memory, optionally filtered. See sync version for details."""
-        rels = await self.list_relations(memory_id)
+        """Find relations for a memory, optionally filtered.
+
+        Async version of :meth:`MemoClaw.find_related`. See sync version for details.
+
+        Args:
+            memory_id: Memory ID to find relations for.
+            relation_type: Filter by relation type.
+            direction: Filter by direction (``"outgoing"`` or ``"incoming"``).
+            timeout: Per-request timeout in seconds. Overrides the client default.
+        """
+        rels = await self.list_relations(memory_id, timeout=timeout)
         if relation_type is not None:
             rels = [r for r in rels if r.relation_type == relation_type]
         if direction is not None:

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1082,7 +1082,7 @@ export class MemoClawClient {
   // ── Graph helpers ─────────────────────────────────────
 
   /** Traverse the memory graph from a starting node up to `depth` hops. */
-  async getMemoryGraph(memoryId: string, depth = 1): Promise<Map<string, ListRelationsResponse['relations']>> {
+  async getMemoryGraph(memoryId: string, depth = 1, options?: RequestOptions): Promise<Map<string, ListRelationsResponse['relations']>> {
     const visited = new Map<string, ListRelationsResponse['relations']>();
     let frontier = [memoryId];
 
@@ -1090,7 +1090,7 @@ export class MemoClawClient {
       const nextFrontier: string[] = [];
       for (const mid of frontier) {
         if (visited.has(mid)) continue;
-        const { relations } = await this.listRelations(mid);
+        const { relations } = await this.listRelations(mid, options);
         visited.set(mid, relations);
         for (const rel of relations) {
           if (!visited.has(rel.memory.id)) {
@@ -1108,12 +1108,13 @@ export class MemoClawClient {
   /** Find relations for a memory, optionally filtered by type and/or direction. */
   async findRelated(
     memoryId: string,
-    options: { relationType?: RelationType; direction?: 'outgoing' | 'incoming' } = {},
+    options: { relationType?: RelationType; direction?: 'outgoing' | 'incoming' } & RequestOptions = {},
   ): Promise<ListRelationsResponse['relations']> {
-    const { relations } = await this.listRelations(memoryId);
+    const { relationType, direction, ...requestOptions } = options;
+    const { relations } = await this.listRelations(memoryId, requestOptions);
     return relations.filter((r) => {
-      if (options.relationType && r.relation_type !== options.relationType) return false;
-      if (options.direction && r.direction !== options.direction) return false;
+      if (relationType && r.relation_type !== relationType) return false;
+      if (direction && r.direction !== direction) return false;
       return true;
     });
   }


### PR DESCRIPTION
## Summary

Fixes two issues with graph helper methods across both SDKs.

### Bug Fix (#173): TS examples use Python-style keyword args
Three TypeScript examples used `depth=2` (Python syntax) instead of positional `2`. In strict mode ESM, this causes a `ReferenceError` since `depth` is undeclared.

**Fixed files:**
- `examples/typescript/graph_traversal.ts`
- `examples/typescript/ai_assistant_example.ts`
- `examples/typescript/advanced_usage.ts`

### Enhancement (#174): Add RequestOptions/timeout to graph helpers
`getMemoryGraph` and `findRelated` were the only public API methods missing request-level options (timeout/abort signal), making them inconsistent with the rest of the API surface.

**TypeScript:**
- `getMemoryGraph(memoryId, depth, options?)` — added `RequestOptions`
- `findRelated(memoryId, options)` — options now extends `RequestOptions` (signal/timeout forwarded to `listRelations`)

**Python (sync + async):**
- `get_memory_graph(memory_id, *, depth, timeout)` — added `timeout`
- `find_related(memory_id, *, relation_type, direction, timeout)` — added `timeout`

### Tests
- TS: 274/274 pass ✅
- Python: 429/429 pass ✅

Fixes #173
Fixes #174