### PR TITLE
fix: SDK audit batch 1 — dead code path, type consistency, deprecation warning

### DIFF
--- a/python/src/memoclaw/config.py
+++ b/python/src/memoclaw/config.py
@@ -78,15 +78,11 @@ def resolve_private_key(
     if config and config.private_key:
         return config.private_key
 
-    # No key found — acceptable only in wallet-only mode
-    if wallet_address is not None:
-        return None
-
-    raise ValueError(
-        "No private key provided. Pass private_key=, set MEMOCLAW_PRIVATE_KEY, "
-        "or run `memoclaw init` to create ~/.memoclaw/config.json. "
-        "Alternatively, pass wallet_address= for read-only access to free endpoints."
-    )
+    # No key found — return None and let the caller decide whether to raise.
+    # When wallet_address is provided the caller operates in wallet-only mode;
+    # when neither key nor wallet is available the caller should raise with a
+    # comprehensive error message covering all authentication options.
+    return None
 
 
 def resolve_wallet_address(

--- a/python/src/memoclaw/types.py
+++ b/python/src/memoclaw/types.py
@@ -148,7 +148,7 @@ class ListResponse(BaseModel):
 
 class DeleteResult(BaseModel):
     deleted: bool
-    id: str | None = None
+    id: str
 
 
 class DeleteBatchItemResult(BaseModel):

--- a/python/tests/test_async_client.py
+++ b/python/tests/test_async_client.py
@@ -170,10 +170,11 @@ class TestAsyncDelete:
     @pytest.mark.asyncio
     async def test_delete(self, client: AsyncMemoClaw):
         respx.delete(f"{BASE_URL}/v1/memories/mem-1").mock(
-            return_value=httpx.Response(200, json={"deleted": True})
+            return_value=httpx.Response(200, json={"deleted": True, "id": "mem-1"})
         )
         result = await client.delete("mem-1")
         assert result.deleted is True
+        assert result.id == "mem-1"
         await client.close()
 
     @respx.mock
@@ -374,10 +375,11 @@ class TestAsyncRelations:
     @pytest.mark.asyncio
     async def test_delete_relation(self, client: AsyncMemoClaw):
         respx.delete(f"{BASE_URL}/v1/memories/mem-1/relations/rel-1").mock(
-            return_value=httpx.Response(200, json={"deleted": True})
+            return_value=httpx.Response(200, json={"deleted": True, "id": "rel-1"})
         )
         result = await client.delete_relation("mem-1", "rel-1")
         assert result.deleted is True
+        assert result.id == "rel-1"
         await client.close()
 
 

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -375,10 +375,11 @@ class TestRelations:
     @respx.mock
     def test_delete_relation(self, client: MemoClaw):
         respx.delete(f"{BASE_URL}/v1/memories/m1/relations/rel1").mock(
-            return_value=httpx.Response(200, json={"deleted": True})
+            return_value=httpx.Response(200, json={"deleted": True, "id": "rel1"})
         )
         result = client.delete_relation("m1", "rel1")
         assert result.deleted is True
+        assert result.id == "rel1"
 
 
 class TestStatus:

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -144,9 +144,11 @@ class TestDeleteResult:
         assert r.deleted is True
         assert r.id == "d1"
 
-    def test_without_id(self):
-        r = DeleteResult(deleted=True)
-        assert r.id is None
+    def test_requires_id(self):
+        """DeleteResult.id is required — the API always returns the memory id."""
+        import pytest
+        with pytest.raises(Exception):  # pydantic ValidationError
+            DeleteResult(deleted=True)
 
 
 class TestIngestResult:

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1078,6 +1078,9 @@ export class MemoClawClient {
    * @deprecated Use {@link iterMemories} instead. Will be removed in a future major version.
    */
   listAll(params: Omit<ListMemoriesParams, 'offset'> & { batchSize?: number } = {}): AsyncGenerator<Memory> {
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[memoclaw] listAll() is deprecated, use iterMemories() instead');
+    }
     return this.iterMemories(params);
   }
 


### PR DESCRIPTION
## Changes

Fixes from SDK audit covering Python ↔ TypeScript consistency:

### Bug Fixes
- **Python `resolve_private_key()` dead code path** (Fixes #181): When both wallet and private key were missing, `resolve_private_key()` raised a ValueError that only mentioned private key options, before the constructor's more comprehensive error message could execute. Now returns `None` and lets the constructor handle the combined no-auth error with a message mentioning both `private_key` and `wallet_address`.

- **Python `DeleteResult.id` now required** (Fixes #182): Was `str | None` (optional) but the API always returns the id. Now matches TS SDK's required `string` type. Updated test mocks to include `id` in delete responses.

### Enhancements
- **TS `listAll()` runtime deprecation warning** (Fixes #184): Added `console.warn()` to match Python's `DeprecationWarning` behavior. JSDoc `@deprecated` only helps IDE users; this catches everyone.

## Testing
- ✅ Python: 429 passed, 2 skipped
- ✅ TypeScript: 276 passed