### PR TITLE
fix: sync version constants with package manifests

### DIFF
--- a/python/src/memoclaw/__init__.py
+++ b/python/src/memoclaw/__init__.py
@@ -1,6 +1,6 @@
 """MemoClaw Python SDK — semantic memory for AI agents."""
 
-__version__ = "0.1.0"
+__version__ = "1.0.0"
 
 from .builders import MemoryBuilder, RecallBuilder
 from .client import AsyncMemoClaw, MemoClaw

--- a/typescript/src/version.ts
+++ b/typescript/src/version.ts
@@ -1,2 +1,2 @@
 /** SDK version, kept in sync with package.json. */
-export const VERSION = '0.1.0';
+export const VERSION = '1.0.0';


### PR DESCRIPTION
## Summary

Update `__version__` in Python `__init__.py` and `VERSION` in TypeScript `version.ts` from `'0.1.0'` to `'1.0.0'` to match `pyproject.toml` and `package.json`.

## Impact
- User-Agent headers now correctly report `memoclaw-sdk-python/1.0.0` and `memoclaw-sdk-ts/1.0.0`
- `memoclaw.__version__` returns correct version in Python
- `import { VERSION } from '@memoclaw/sdk'` returns correct version in TypeScript

Fixes #186