### PR TITLE
feat: add Node.js engines field to TypeScript package.json

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -29,6 +29,9 @@
     "sdk",
     "semantic-search"
   ],
+  "engines": {
+    "node": ">=18"
+  },
   "license": "MIT",
   "author": "MemoClaw",
   "repository": {


### PR DESCRIPTION
## Summary

Add `"engines": { "node": ">=18" }` to the TypeScript SDK's `package.json`. This matches the CI test matrix (Node 18, 20, 22) and helps npm warn users running unsupported Node.js versions.

Closes #187