### PR TITLE
feat: add expiresInDays() to TS StoreBuilder

### DIFF
--- a/typescript/src/builders.ts
+++ b/typescript/src/builders.ts
@@ -778,6 +778,14 @@ export class StoreBuilder {
     return this;
   }
 
+  /** Set expiration relative to now (in days). */
+  expiresInDays(days: number): StoreBuilder {
+    const date = new Date();
+    date.setDate(date.getDate() + days);
+    this._expiresAt = date.toISOString();
+    return this;
+  }
+
   /** Pin the memory. */
   pinned(pinned = true): StoreBuilder {
     this._pinned = pinned;


### PR DESCRIPTION
## Summary

Add a convenience method `expiresInDays(days)` to `StoreBuilder` that sets the memory's `expires_at` relative to the current time.

### Example
```ts
const builder = client.store('temp note').expiresInDays(7);
```

This computes the ISO date string internally, so users don't need to manually construct dates.

Closes #188