### PR TITLE
feat: add exists() method and retry attempt count (#196, #198)

### DIFF
--- a/python/src/memoclaw/_client.py
+++ b/python/src/memoclaw/_client.py
@@ -116,7 +116,7 @@ def _generate_wallet_only_auth(wallet_address: str) -> str:
     return wallet_address
 
 
-def _raise_for_status(response: httpx.Response) -> None:
+def _raise_for_status(response: httpx.Response, *, retry_attempts: int = 0) -> None:
     """Raise a typed :class:`APIError` for non-2xx responses."""
     if response.is_success:
         return
@@ -125,7 +125,9 @@ def _raise_for_status(response: httpx.Response) -> None:
     except Exception:
         body = {"error": {"code": "UNKNOWN", "message": response.text}}
     request_id = response.headers.get("x-request-id")
-    raise APIError.from_response(response.status_code, body, request_id=request_id)
+    raise APIError.from_response(
+        response.status_code, body, request_id=request_id, retry_attempts=retry_attempts
+    )
 
 
 def _try_x402_payment(
@@ -240,10 +242,25 @@ class _SyncHTTPClient:
             if response.status_code == 402:
                 payment_headers = _try_x402_payment(response)
                 if payment_headers:
+                    logger.info("x402 payment headers created, retrying %s %s", method, path)
                     headers.update(payment_headers)
                     response = self._http.request(
                         method, url, headers=headers, json=json, params=params,
                         timeout=req_timeout,
+                    )
+                    x402_duration_ms = round((time.monotonic() - start) * 1000)
+                    x402_req_id = response.headers.get("x-request-id", "")
+                    logger.debug(
+                        "%s %s → %d (%dms, x402 paid)%s",
+                        method, path, response.status_code, x402_duration_ms,
+                        f" req={x402_req_id}" if x402_req_id else "",
+                        extra={
+                            "method": method,
+                            "path": path,
+                            "status": response.status_code,
+                            "duration_ms": x402_duration_ms,
+                            "request_id": x402_req_id or None,
+                        },
                     )
 
             # Retry on transient server errors (429, 500, 502, 503, 504)
@@ -262,7 +279,7 @@ class _SyncHTTPClient:
                 time.sleep(delay)
                 continue
 
-            _raise_for_status(response)
+            _raise_for_status(response, retry_attempts=attempt)
 
             if response.status_code == 204:
                 return {}
@@ -271,7 +288,7 @@ class _SyncHTTPClient:
         # Should not reach here, but raise last error if we do
         if last_exc is not None:
             raise last_exc
-        _raise_for_status(response)
+        _raise_for_status(response, retry_attempts=attempt)
 
     def close(self) -> None:
         self._http.close()
@@ -377,10 +394,25 @@ class _AsyncHTTPClient:
             if response.status_code == 402:
                 payment_headers = _try_x402_payment(response)
                 if payment_headers:
+                    logger.info("x402 payment headers created, retrying %s %s", method, path)
                     headers.update(payment_headers)
                     response = await self._http.request(
                         method, url, headers=headers, json=json, params=params,
                         timeout=req_timeout,
+                    )
+                    x402_duration_ms = round((time.monotonic() - start) * 1000)
+                    x402_req_id = response.headers.get("x-request-id", "")
+                    logger.debug(
+                        "%s %s → %d (%dms, x402 paid)%s",
+                        method, path, response.status_code, x402_duration_ms,
+                        f" req={x402_req_id}" if x402_req_id else "",
+                        extra={
+                            "method": method,
+                            "path": path,
+                            "status": response.status_code,
+                            "duration_ms": x402_duration_ms,
+                            "request_id": x402_req_id or None,
+                        },
                     )
 
             # Retry on transient server errors (429, 500, 502, 503, 504)
@@ -399,7 +431,7 @@ class _AsyncHTTPClient:
                 await asyncio.sleep(delay)
                 continue
 
-            _raise_for_status(response)
+            _raise_for_status(response, retry_attempts=attempt)
 
             if response.status_code == 204:
                 return {}
@@ -407,7 +439,7 @@ class _AsyncHTTPClient:
 
         if last_exc is not None:
             raise last_exc
-        _raise_for_status(response)
+        _raise_for_status(response, retry_attempts=attempt)
 
     async def close(self) -> None:
         await self._http.aclose()

--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -26,6 +26,7 @@ from ._client import (
     configure_sdk_logging,
 )
 from .builders import StoreBuilder, AsyncStoreBuilder
+from .errors import APIError
 from .config import load_config, resolve_base_url, resolve_private_key, resolve_wallet_address
 from .types import (
     ConsolidateResult,
@@ -609,6 +610,31 @@ class MemoClaw:
         _validate_non_empty(memory_id, "memory_id")
         data = self._run_request("GET", f"/v1/memories/{quote(memory_id, safe='')}", timeout=timeout)
         return Memory.model_validate(data)
+
+    def exists(self, memory_id: str, *, timeout: float | None = None) -> bool:
+        """Check whether a memory exists by ID.
+
+        Returns ``True`` if the memory exists, ``False`` if it has been deleted
+        or never existed (404). Other errors (auth, network) are raised normally.
+
+        This uses the free ``GET /v1/memories/{id}`` endpoint, so it works in
+        wallet-only mode.
+
+        Example::
+
+            if client.exists("mem-123"):
+                client.update("mem-123", content="Updated")
+            else:
+                client.store("New memory")
+        """
+        _validate_non_empty(memory_id, "memory_id")
+        try:
+            self._run_request("GET", f"/v1/memories/{quote(memory_id, safe='')}", timeout=timeout)
+            return True
+        except APIError as exc:
+            if exc.status_code == 404:
+                return False
+            raise
 
     # ── Update ───────────────────────────────────────────────────────────
 
@@ -1883,6 +1909,31 @@ class AsyncMemoClaw:
         _validate_non_empty(memory_id, "memory_id")
         data = await self._run_request("GET", f"/v1/memories/{quote(memory_id, safe='')}", timeout=timeout)
         return Memory.model_validate(data)
+
+    async def exists(self, memory_id: str, *, timeout: float | None = None) -> bool:
+        """Check whether a memory exists by ID.
+
+        Returns ``True`` if the memory exists, ``False`` if it has been deleted
+        or never existed (404). Other errors (auth, network) are raised normally.
+
+        This uses the free ``GET /v1/memories/{id}`` endpoint, so it works in
+        wallet-only mode.
+
+        Example::
+
+            if await client.exists("mem-123"):
+                await client.update("mem-123", content="Updated")
+            else:
+                await client.store("New memory")
+        """
+        _validate_non_empty(memory_id, "memory_id")
+        try:
+            await self._run_request("GET", f"/v1/memories/{quote(memory_id, safe='')}", timeout=timeout)
+            return True
+        except APIError as exc:
+            if exc.status_code == 404:
+                return False
+            raise
 
     # ── Update ───────────────────────────────────────────────────────────
 

--- a/python/src/memoclaw/errors.py
+++ b/python/src/memoclaw/errors.py
@@ -76,6 +76,8 @@ class APIError(MemoClawError):
         details: Optional structured error details.
         suggestion: Actionable suggestion for fixing the error.
         request_id: Server-side request ID from the ``x-request-id`` header, if available.
+        retry_attempts: Number of retry attempts made before this error was raised.
+            ``0`` means the error occurred on the first attempt with no retries.
     """
 
     status_code: int
@@ -84,6 +86,7 @@ class APIError(MemoClawError):
     details: dict[str, Any] | None
     suggestion: str | None
     request_id: str | None
+    retry_attempts: int
 
     def __init__(
         self,
@@ -93,22 +96,33 @@ class APIError(MemoClawError):
         details: dict[str, Any] | None = None,
         *,
         request_id: str | None = None,
+        retry_attempts: int = 0,
     ) -> None:
         self.status_code = status_code
         self.code = code
         self.message = message
         self.details = details
         self.request_id = request_id
+        self.retry_attempts = retry_attempts
         self.suggestion = _get_suggestion(status_code, code)
         msg = f"[{status_code}] {code}: {message}"
         if self.request_id:
             msg += f"\n  request-id: {self.request_id}"
+        if self.retry_attempts > 0:
+            msg += f"\n  retries: {self.retry_attempts}"
         if self.suggestion:
             msg += f"\n  💡 {self.suggestion}"
         super().__init__(msg)
 
     @classmethod
-    def from_response(cls, status_code: int, body: dict[str, Any], *, request_id: str | None = None) -> APIError:
+    def from_response(
+        cls,
+        status_code: int,
+        body: dict[str, Any],
+        *,
+        request_id: str | None = None,
+        retry_attempts: int = 0,
+    ) -> APIError:
         """Create the most specific error subclass from an API error response."""
         error = body.get("error", {})
         code = error.get("code", "UNKNOWN")
@@ -122,6 +136,7 @@ class APIError(MemoClawError):
             message=message,
             details=details,
             request_id=request_id,
+            retry_attempts=retry_attempts,
         )
 
 

--- a/python/tests/test_async_client.py
+++ b/python/tests/test_async_client.py
@@ -123,6 +123,42 @@ class TestAsyncGet:
         await client.close()
 
 
+class TestAsyncExists:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_exists_returns_true(self, client: AsyncMemoClaw):
+        respx.get(f"{BASE_URL}/v1/memories/mem-1").mock(
+            return_value=httpx.Response(200, json=_MEM_JSON)
+        )
+        assert await client.exists("mem-1") is True
+        await client.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_exists_returns_false_on_404(self, client: AsyncMemoClaw):
+        respx.get(f"{BASE_URL}/v1/memories/nonexistent").mock(
+            return_value=httpx.Response(
+                404,
+                json={"error": {"code": "NOT_FOUND", "message": "Memory not found"}},
+            )
+        )
+        assert await client.exists("nonexistent") is False
+        await client.close()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_exists_raises_on_server_error(self, client: AsyncMemoClaw):
+        respx.get(f"{BASE_URL}/v1/memories/mem-1").mock(
+            return_value=httpx.Response(
+                500,
+                json={"error": {"code": "INTERNAL", "message": "Server error"}},
+            )
+        )
+        with pytest.raises(Exception):
+            await client.exists("mem-1")
+        await client.close()
+
+
 class TestAsyncUpdate:
     @respx.mock
     @pytest.mark.asyncio

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -177,6 +177,61 @@ class TestGet:
         assert result.content == "Test content"
 
 
+class TestExists:
+    @respx.mock
+    def test_exists_returns_true(self, client: MemoClaw):
+        respx.get(f"{BASE_URL}/v1/memories/mem-123").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "mem-123",
+                    "user_id": "u1",
+                    "namespace": "default",
+                    "content": "Test content",
+                    "embedding_model": "text-embedding-3-small",
+                    "metadata": {},
+                    "importance": 0.8,
+                    "memory_type": "general",
+                    "session_id": None,
+                    "agent_id": None,
+                    "created_at": "2025-01-01T00:00:00Z",
+                    "updated_at": "2025-01-01T00:00:00Z",
+                    "accessed_at": "2025-01-01T00:00:00Z",
+                    "access_count": 1,
+                    "deleted_at": None,
+                    "expires_at": None,
+                    "pinned": False,
+                },
+            )
+        )
+        assert client.exists("mem-123") is True
+
+    @respx.mock
+    def test_exists_returns_false_on_404(self, client: MemoClaw):
+        respx.get(f"{BASE_URL}/v1/memories/nonexistent").mock(
+            return_value=httpx.Response(
+                404,
+                json={"error": {"code": "NOT_FOUND", "message": "Memory not found"}},
+            )
+        )
+        assert client.exists("nonexistent") is False
+
+    @respx.mock
+    def test_exists_raises_on_other_errors(self, client: MemoClaw):
+        respx.get(f"{BASE_URL}/v1/memories/mem-123").mock(
+            return_value=httpx.Response(
+                500,
+                json={"error": {"code": "INTERNAL", "message": "Server error"}},
+            )
+        )
+        with pytest.raises(Exception):
+            client.exists("mem-123")
+
+    def test_exists_raises_on_empty_id(self, client: MemoClaw):
+        with pytest.raises((ValueError, ValidationError)):
+            client.exists("")
+
+
 class TestUpdate:
     @respx.mock
     def test_update_content(self, client: MemoClaw):

--- a/typescript/src/__tests__/client.test.ts
+++ b/typescript/src/__tests__/client.test.ts
@@ -154,6 +154,35 @@ describe('MemoClawClient', () => {
     });
   });
 
+  describe('exists', () => {
+    it('returns true when memory exists (200)', async () => {
+      const mem = { id: 'mem-1', user_id: 'u1', namespace: 'default', content: 'hello', embedding_model: 'e', metadata: {}, importance: 0.5, memory_type: 'general', session_id: null, agent_id: null, created_at: '', updated_at: '', accessed_at: '', access_count: 0, deleted_at: null, expires_at: null, pinned: false, immutable: false };
+      const f = mockFetch([{ status: 200, body: mem }]);
+      const client = createClient(f);
+      const result = await client.exists('mem-1');
+      expect(result).toBe(true);
+    });
+
+    it('returns false when memory does not exist (404)', async () => {
+      const f = mockFetch([{ status: 404, ok: false, body: { error: { code: 'NOT_FOUND', message: 'Memory not found' } } }]);
+      const client = createClient(f);
+      const result = await client.exists('nonexistent');
+      expect(result).toBe(false);
+    });
+
+    it('throws on other errors (e.g. 500)', async () => {
+      const f = mockFetch([{ status: 500, ok: false, body: { error: { code: 'INTERNAL', message: 'Server error' } } }]);
+      const client = createClient(f);
+      await expect(client.exists('mem-1')).rejects.toThrow();
+    });
+
+    it('throws on empty id', async () => {
+      const f = mockFetch([]);
+      const client = createClient(f);
+      await expect(client.exists('')).rejects.toThrow('id must be a non-empty string');
+    });
+  });
+
   describe('update', () => {
     it('sends PATCH /v1/memories/:id', async () => {
       const mem = { id: 'mem-1', user_id: 'u1', namespace: 'default', content: 'updated', embedding_model: 'e', metadata: {}, importance: 0.9, memory_type: 'general', session_id: null, agent_id: null, created_at: '', updated_at: '', accessed_at: '', access_count: 0, deleted_at: null, expires_at: null, pinned: false, immutable: false };

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -429,6 +429,7 @@ export class MemoClawClient {
         const details = errorBody?.error?.details;
         lastError = createError(res.status, code, message, details);
         lastError.requestId = res.headers?.get('x-request-id') ?? undefined;
+        lastError.retryAttempts = attempt;
 
         this._logger?.warn(`${method} ${path} → ${res.status} [${code}], retrying in ${delay}ms (attempt ${attempt + 1}/${this.maxRetries})`, {
           method, path, status: res.status, request_id: lastError?.requestId,
@@ -492,6 +493,7 @@ export class MemoClawClient {
 
       lastError = createError(res.status, code, message, details);
       lastError.requestId = res.headers?.get('x-request-id') ?? undefined;
+      lastError.retryAttempts = attempt;
 
       const duration = Date.now() - startTime;
       this._logger?.error(`${method} ${path} → ${res.status} [${code}] (${duration}ms)`, lastError.requestId ? `req=${lastError.requestId}` : '', {
@@ -629,6 +631,34 @@ export class MemoClawClient {
   async get(id: string, options?: RequestOptions): Promise<Memory> {
     if (!id?.trim()) throw new Error('id must be a non-empty string');
     return this.request<Memory>('GET', `/v1/memories/${encodeURIComponent(id)}`, undefined, undefined, options);
+  }
+
+  /**
+   * Check whether a memory exists by ID.
+   *
+   * Returns `true` if the memory exists, `false` if it was deleted or never
+   * existed (404). Other errors (auth, network) are raised normally.
+   *
+   * Uses the free `GET /v1/memories/{id}` endpoint — works in wallet-only mode.
+   *
+   * @example
+   * ```ts
+   * if (await client.exists('mem-123')) {
+   *   await client.update('mem-123', { content: 'Updated' });
+   * }
+   * ```
+   */
+  async exists(id: string, options?: RequestOptions): Promise<boolean> {
+    if (!id?.trim()) throw new Error('id must be a non-empty string');
+    try {
+      await this.request<Memory>('GET', `/v1/memories/${encodeURIComponent(id)}`, undefined, undefined, options);
+      return true;
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        return false;
+      }
+      throw err;
+    }
   }
 
   /** Update a memory by ID. */

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -67,6 +67,9 @@ export class MemoClawError extends Error {
   public readonly suggestion?: string;
   /** Server-side request ID from the `x-request-id` response header, if available. */
   public requestId?: string;
+  /** Number of retry attempts made before this error was raised.
+   *  `0` means the error occurred on the first attempt with no retries. */
+  public retryAttempts: number = 0;
 
   constructor(
     public readonly status: number,
@@ -83,6 +86,7 @@ export class MemoClawError extends Error {
   override toString(): string {
     let str = `${this.name} [${this.code}] (${this.status}): ${this.message}`;
     if (this.requestId) str += `\n  request-id: ${this.requestId}`;
+    if (this.retryAttempts > 0) str += `\n  retries: ${this.retryAttempts}`;
     if (this.suggestion) str += `\n  → ${this.suggestion}`;
     return str;
   }


### PR DESCRIPTION
## Changes

### exists() convenience method (closes #196)
- **Python**: `MemoClaw.exists()` and `AsyncMemoClaw.exists()`
- **TypeScript**: `MemoClawClient.exists()`
- Returns `true` if memory exists, `false` on 404, raises on other errors
- Uses the free `GET /v1/memories/{id}` endpoint (works in wallet-only mode)
- Tests for Python sync, Python async, and TypeScript

### Retry attempt count in error context (closes #198)
- **Python**: `APIError.retry_attempts` field
- **TypeScript**: `MemoClawError.retryAttempts` field
- Both default to 0 (first attempt, no retries)
- Displayed in error string when > 0 for easier debugging

## Tests
- All 282 TypeScript tests pass
- All 441 Python tests pass (2 skipped, 5 deprecation warnings)