### PR TITLE
feat(ts): add OpenAI-compatible tool definitions

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -10,6 +10,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./tools": {
+      "import": "./dist/tools.js",
+      "types": "./dist/tools.d.ts"
     }
   },
   "files": [

--- a/typescript/src/__tests__/tools.test.ts
+++ b/typescript/src/__tests__/tools.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  getMemoclawTools,
+  getMemoclawTool,
+  getMemoclawToolNames,
+  executeMemoclawTool,
+  type ToolDefinition,
+  type ToolCall,
+} from '../tools.js';
+import { MemoClawClient } from '../client.js';
+
+// Well-known Hardhat test private key (DO NOT use in production)
+const TEST_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+function mockFetch(responses: Array<{ status: number; body?: unknown; ok?: boolean }>): typeof globalThis.fetch {
+  let callIndex = 0;
+  return vi.fn(async () => {
+    const resp = responses[callIndex] ?? responses[responses.length - 1]!;
+    callIndex++;
+    return {
+      ok: resp.ok ?? (resp.status >= 200 && resp.status < 300),
+      status: resp.status,
+      json: async () => resp.body,
+      headers: { get: () => null },
+    } as unknown as Response;
+  });
+}
+
+function createClient(fetchFn: typeof globalThis.fetch) {
+  return new MemoClawClient({
+    privateKey: TEST_PRIVATE_KEY,
+    baseUrl: 'https://api.memoclaw.com',
+    fetch: fetchFn,
+    maxRetries: 0,
+    retryDelay: 1,
+  });
+}
+
+describe('getMemoclawTools', () => {
+  it('returns all 5 tools by default', () => {
+    const tools = getMemoclawTools();
+    expect(tools).toHaveLength(5);
+    const names = tools.map((t) => t.function.name);
+    expect(names).toContain('store_memory');
+    expect(names).toContain('recall_memories');
+    expect(names).toContain('list_memories');
+    expect(names).toContain('delete_memory');
+    expect(names).toContain('get_memory');
+  });
+
+  it('all tools have type "function"', () => {
+    const tools = getMemoclawTools();
+    for (const tool of tools) {
+      expect(tool.type).toBe('function');
+    }
+  });
+
+  it('all tools have valid OpenAI schema structure', () => {
+    const tools = getMemoclawTools();
+    for (const tool of tools) {
+      expect(tool.function.name).toBeTruthy();
+      expect(tool.function.description).toBeTruthy();
+      expect(tool.function.parameters.type).toBe('object');
+      expect(tool.function.parameters.properties).toBeDefined();
+    }
+  });
+
+  it('filters with include option', () => {
+    const tools = getMemoclawTools({ include: ['store_memory', 'recall_memories'] });
+    expect(tools).toHaveLength(2);
+    const names = tools.map((t) => t.function.name);
+    expect(names).toEqual(['store_memory', 'recall_memories']);
+  });
+
+  it('filters with exclude option', () => {
+    const tools = getMemoclawTools({ exclude: ['delete_memory'] });
+    expect(tools).toHaveLength(4);
+    const names = tools.map((t) => t.function.name);
+    expect(names).not.toContain('delete_memory');
+  });
+
+  it('include + exclude combined', () => {
+    const tools = getMemoclawTools({
+      include: ['store_memory', 'recall_memories', 'delete_memory'],
+      exclude: ['delete_memory'],
+    });
+    expect(tools).toHaveLength(2);
+    const names = tools.map((t) => t.function.name);
+    expect(names).toEqual(['store_memory', 'recall_memories']);
+  });
+
+  it('returns empty array for non-existent include', () => {
+    const tools = getMemoclawTools({ include: ['nonexistent_tool'] });
+    expect(tools).toHaveLength(0);
+  });
+
+  it('returns new array on each call (no mutation)', () => {
+    const tools1 = getMemoclawTools();
+    const tools2 = getMemoclawTools();
+    expect(tools1).not.toBe(tools2);
+    expect(tools1).toEqual(tools2);
+  });
+});
+
+describe('getMemoclawTool', () => {
+  it('returns a tool definition by name', () => {
+    const tool = getMemoclawTool('store_memory');
+    expect(tool).toBeDefined();
+    expect(tool!.function.name).toBe('store_memory');
+  });
+
+  it('returns undefined for unknown name', () => {
+    const tool = getMemoclawTool('nonexistent');
+    expect(tool).toBeUndefined();
+  });
+});
+
+describe('getMemoclawToolNames', () => {
+  it('returns all tool names', () => {
+    const names = getMemoclawToolNames();
+    expect(names).toEqual([
+      'store_memory',
+      'recall_memories',
+      'list_memories',
+      'delete_memory',
+      'get_memory',
+    ]);
+  });
+});
+
+describe('store_memory tool schema', () => {
+  it('requires content', () => {
+    const tool = getMemoclawTool('store_memory')!;
+    expect(tool.function.parameters.required).toContain('content');
+  });
+
+  it('has importance with min/max', () => {
+    const tool = getMemoclawTool('store_memory')!;
+    const importance = tool.function.parameters.properties['importance']!;
+    expect(importance.minimum).toBe(0);
+    expect(importance.maximum).toBe(1);
+  });
+
+  it('has memory_type enum', () => {
+    const tool = getMemoclawTool('store_memory')!;
+    const memType = tool.function.parameters.properties['memory_type']!;
+    expect(memType.enum).toEqual([
+      'correction', 'preference', 'decision', 'project', 'observation', 'general',
+    ]);
+  });
+});
+
+describe('recall_memories tool schema', () => {
+  it('requires query', () => {
+    const tool = getMemoclawTool('recall_memories')!;
+    expect(tool.function.parameters.required).toContain('query');
+  });
+});
+
+describe('executeMemoclawTool', () => {
+  it('executes store_memory', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { id: 'mem-1', stored: true, deduplicated: false, tokens_used: 10 } },
+    ]);
+    const client = createClient(fetchFn);
+
+    const result = await executeMemoclawTool(client, {
+      id: 'call-1',
+      function: {
+        name: 'store_memory',
+        arguments: JSON.stringify({ content: 'Test memory', importance: 0.8 }),
+      },
+    });
+
+    expect(result.tool_call_id).toBe('call-1');
+    expect(result.name).toBe('store_memory');
+    expect(result.is_error).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.id).toBe('mem-1');
+    expect(parsed.stored).toBe(true);
+  });
+
+  it('executes store_memory with tags', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { id: 'mem-2', stored: true, deduplicated: false, tokens_used: 10 } },
+    ]);
+    const client = createClient(fetchFn);
+
+    await executeMemoclawTool(client, {
+      id: 'call-2',
+      function: {
+        name: 'store_memory',
+        arguments: JSON.stringify({
+          content: 'Tagged memory',
+          tags: ['important', 'project-x'],
+          namespace: 'test',
+        }),
+      },
+    });
+
+    // Verify the fetch was called with proper body
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const callArgs = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0] as [string, { body: string }];
+    const body = JSON.parse(callArgs[1].body);
+    expect(body.content).toBe('Tagged memory');
+    expect(body.metadata).toEqual({ tags: ['important', 'project-x'] });
+    expect(body.namespace).toBe('test');
+  });
+
+  it('executes recall_memories', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 200,
+        body: {
+          memories: [{ id: 'mem-1', content: 'Test', similarity: 0.95 }],
+          query_tokens: 5,
+        },
+      },
+    ]);
+    const client = createClient(fetchFn);
+
+    const result = await executeMemoclawTool(client, {
+      id: 'call-3',
+      function: {
+        name: 'recall_memories',
+        arguments: JSON.stringify({ query: 'test', limit: 5 }),
+      },
+    });
+
+    expect(result.is_error).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.memories).toHaveLength(1);
+  });
+
+  it('executes recall_memories with filters', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { memories: [], query_tokens: 3 } },
+    ]);
+    const client = createClient(fetchFn);
+
+    await executeMemoclawTool(client, {
+      function: {
+        name: 'recall_memories',
+        arguments: JSON.stringify({
+          query: 'test',
+          tags: ['bug'],
+          memory_type: 'correction',
+          namespace: 'prod',
+        }),
+      },
+    });
+
+    const callArgs = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0] as [string, { body: string }];
+    const body = JSON.parse(callArgs[1].body);
+    expect(body.filters).toEqual({ tags: ['bug'], memory_type: 'correction' });
+    expect(body.namespace).toBe('prod');
+  });
+
+  it('executes list_memories', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 200,
+        body: { memories: [], total: 0, limit: 20, offset: 0 },
+      },
+    ]);
+    const client = createClient(fetchFn);
+
+    const result = await executeMemoclawTool(client, {
+      id: 'call-4',
+      function: {
+        name: 'list_memories',
+        arguments: JSON.stringify({ limit: 10, namespace: 'test' }),
+      },
+    });
+
+    expect(result.is_error).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.total).toBe(0);
+  });
+
+  it('executes delete_memory', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { deleted: true, id: 'mem-1' } },
+    ]);
+    const client = createClient(fetchFn);
+
+    const result = await executeMemoclawTool(client, {
+      id: 'call-5',
+      function: {
+        name: 'delete_memory',
+        arguments: JSON.stringify({ id: 'mem-1' }),
+      },
+    });
+
+    expect(result.is_error).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.deleted).toBe(true);
+  });
+
+  it('executes get_memory', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 200,
+        body: { id: 'mem-1', content: 'Hello', importance: 0.5 },
+      },
+    ]);
+    const client = createClient(fetchFn);
+
+    const result = await executeMemoclawTool(client, {
+      id: 'call-6',
+      function: {
+        name: 'get_memory',
+        arguments: JSON.stringify({ id: 'mem-1' }),
+      },
+    });
+
+    expect(result.is_error).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.content).toBe('Hello');
+  });
+
+  it('returns error for unknown tool', async () => {
+    const fetchFn = mockFetch([]);
+    const client = createClient(fetchFn);
+
+    const result = await executeMemoclawTool(client, {
+      id: 'call-err',
+      function: {
+        name: 'unknown_tool',
+        arguments: '{}',
+      },
+    });
+
+    expect(result.is_error).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('Unknown tool');
+  });
+
+  it('returns error for invalid JSON arguments', async () => {
+    const fetchFn = mockFetch([]);
+    const client = createClient(fetchFn);
+
+    const result = await executeMemoclawTool(client, {
+      id: 'call-bad-json',
+      function: {
+        name: 'store_memory',
+        arguments: 'not valid json',
+      },
+    });
+
+    expect(result.is_error).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('Invalid JSON');
+  });
+
+  it('handles API errors gracefully', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 401,
+        ok: false,
+        body: { error: { code: 'UNAUTHORIZED', message: 'Invalid wallet' } },
+      },
+    ]);
+    const client = createClient(fetchFn);
+
+    const result = await executeMemoclawTool(client, {
+      id: 'call-api-err',
+      function: {
+        name: 'get_memory',
+        arguments: JSON.stringify({ id: 'mem-1' }),
+      },
+    });
+
+    expect(result.is_error).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toBeTruthy();
+  });
+
+  it('handles missing tool_call_id', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { id: 'mem-1', content: 'Hi', importance: 0.5 } },
+    ]);
+    const client = createClient(fetchFn);
+
+    const result = await executeMemoclawTool(client, {
+      function: {
+        name: 'get_memory',
+        arguments: JSON.stringify({ id: 'mem-1' }),
+      },
+    });
+
+    expect(result.tool_call_id).toBeUndefined();
+    expect(result.name).toBe('get_memory');
+    expect(result.is_error).toBeUndefined();
+  });
+});

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,4 +1,18 @@
 export { MemoClawClient } from './client.js';
+export {
+  getMemoclawTools,
+  getMemoclawTool,
+  getMemoclawToolNames,
+  executeMemoclawTool,
+} from './tools.js';
+export type {
+  ToolDefinition,
+  ToolCall,
+  ToolResult,
+  FunctionDefinition,
+  FunctionParameters,
+  GetToolsOptions,
+} from './tools.js';
 export { VERSION } from './version.js';
 export { MemoryBuilder, RecallBuilder } from './builders.js';
 export { loadConfig, type MemoClawConfig } from './config.js';

--- a/typescript/src/tools.ts
+++ b/typescript/src/tools.ts
@@ -1,0 +1,443 @@
+/**
+ * OpenAI-compatible tool definitions for MemoClaw.
+ *
+ * Provides pre-built function/tool definitions that work with OpenAI's
+ * function calling API, Vercel AI SDK, and any framework that accepts
+ * the OpenAI tool format.
+ *
+ * @example
+ * ```ts
+ * import { MemoClawClient } from '@memoclaw/sdk';
+ * import { getMemoclawTools, executeMemoclawTool } from '@memoclaw/sdk/tools';
+ *
+ * const client = new MemoClawClient({ privateKey: '0x...' });
+ * const tools = getMemoclawTools();
+ *
+ * // Pass tools to OpenAI
+ * const response = await openai.chat.completions.create({
+ *   model: 'gpt-4',
+ *   messages,
+ *   tools,
+ * });
+ *
+ * // Execute the tool call
+ * const toolCall = response.choices[0].message.tool_calls[0];
+ * const result = await executeMemoclawTool(client, toolCall);
+ * ```
+ *
+ * @module
+ */
+
+import type { MemoClawClient } from './client.js';
+import type { MemoryType } from './types.js';
+
+// ── OpenAI Tool Types ────────────────────────────────────
+
+/** OpenAI function parameter schema (JSON Schema subset). */
+export interface FunctionParameters {
+  type: 'object';
+  properties: Record<string, {
+    type: string;
+    description?: string;
+    enum?: string[];
+    items?: { type: string; enum?: string[] };
+    minimum?: number;
+    maximum?: number;
+    default?: unknown;
+  }>;
+  required?: string[];
+}
+
+/** OpenAI function definition. */
+export interface FunctionDefinition {
+  name: string;
+  description: string;
+  parameters: FunctionParameters;
+}
+
+/** OpenAI tool definition (function type). */
+export interface ToolDefinition {
+  type: 'function';
+  function: FunctionDefinition;
+}
+
+/** Shape of a tool call from OpenAI's API response. */
+export interface ToolCall {
+  id?: string;
+  type?: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+/** Result of executing a tool call. */
+export interface ToolResult {
+  /** The tool call ID (echoed back for OpenAI). */
+  tool_call_id?: string;
+  /** The tool name that was executed. */
+  name: string;
+  /** JSON-stringified result of the tool execution. */
+  content: string;
+  /** Whether the tool execution resulted in an error. */
+  is_error?: boolean;
+}
+
+// ── Tool Definitions ─────────────────────────────────────
+
+const MEMORY_TYPES: MemoryType[] = [
+  'correction', 'preference', 'decision', 'project', 'observation', 'general',
+];
+
+const storeMemoryTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'store_memory',
+    description:
+      'Store a new memory in MemoClaw. Use this to save important information, ' +
+      'preferences, corrections, decisions, or observations that should be remembered.',
+    parameters: {
+      type: 'object',
+      properties: {
+        content: {
+          type: 'string',
+          description: 'The memory content to store (max 8192 characters).',
+        },
+        importance: {
+          type: 'number',
+          description: 'Importance score from 0.0 (trivial) to 1.0 (critical). Default: 0.5.',
+          minimum: 0,
+          maximum: 1,
+        },
+        memory_type: {
+          type: 'string',
+          description: 'Category of the memory.',
+          enum: MEMORY_TYPES,
+        },
+        namespace: {
+          type: 'string',
+          description: 'Namespace to isolate this memory (e.g., project name).',
+        },
+        tags: {
+          type: 'array',
+          description: 'Tags for filtering and organization.',
+          items: { type: 'string' },
+        },
+      },
+      required: ['content'],
+    },
+  },
+};
+
+const recallMemoriesTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'recall_memories',
+    description:
+      'Search for relevant memories using semantic similarity. ' +
+      'Use this to find previously stored information related to a topic or query.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Natural language search query.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of memories to return. Default: 5.',
+          minimum: 1,
+          maximum: 50,
+        },
+        min_similarity: {
+          type: 'number',
+          description: 'Minimum similarity threshold (0.0–1.0). Default: 0.0.',
+          minimum: 0,
+          maximum: 1,
+        },
+        namespace: {
+          type: 'string',
+          description: 'Filter by namespace.',
+        },
+        tags: {
+          type: 'array',
+          description: 'Filter by tags.',
+          items: { type: 'string' },
+        },
+        memory_type: {
+          type: 'string',
+          description: 'Filter by memory type.',
+          enum: MEMORY_TYPES,
+        },
+      },
+      required: ['query'],
+    },
+  },
+};
+
+const listMemoriesTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'list_memories',
+    description:
+      'List stored memories with optional filters. Use this to browse or paginate through memories.',
+    parameters: {
+      type: 'object',
+      properties: {
+        limit: {
+          type: 'number',
+          description: 'Maximum number of memories to return. Default: 20.',
+          minimum: 1,
+          maximum: 100,
+        },
+        offset: {
+          type: 'number',
+          description: 'Pagination offset. Default: 0.',
+          minimum: 0,
+        },
+        namespace: {
+          type: 'string',
+          description: 'Filter by namespace.',
+        },
+        tags: {
+          type: 'array',
+          description: 'Filter by tags.',
+          items: { type: 'string' },
+        },
+        memory_type: {
+          type: 'string',
+          description: 'Filter by memory type.',
+          enum: MEMORY_TYPES,
+        },
+      },
+      required: [],
+    },
+  },
+};
+
+const deleteMemoryTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'delete_memory',
+    description:
+      'Delete a specific memory by its ID. This is a soft delete — the memory can still be found with include_deleted.',
+    parameters: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'The memory ID to delete.',
+        },
+      },
+      required: ['id'],
+    },
+  },
+};
+
+const getMemoryTool: ToolDefinition = {
+  type: 'function',
+  function: {
+    name: 'get_memory',
+    description: 'Retrieve a single memory by its ID.',
+    parameters: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'The memory ID to retrieve.',
+        },
+      },
+      required: ['id'],
+    },
+  },
+};
+
+/** All available MemoClaw tool definitions. */
+const ALL_TOOLS: ReadonlyArray<ToolDefinition> = [
+  storeMemoryTool,
+  recallMemoriesTool,
+  listMemoriesTool,
+  deleteMemoryTool,
+  getMemoryTool,
+];
+
+/** Map of tool names to their definitions for quick lookup. */
+const TOOL_MAP: ReadonlyMap<string, ToolDefinition> = new Map(
+  ALL_TOOLS.map((t) => [t.function.name, t]),
+);
+
+// ── Public API ───────────────────────────────────────────
+
+/** Options for filtering which tools to return. */
+export interface GetToolsOptions {
+  /** Only include tools with these names. If omitted, all tools are returned. */
+  include?: string[];
+  /** Exclude tools with these names. Applied after include. */
+  exclude?: string[];
+}
+
+/**
+ * Get OpenAI-compatible tool definitions for MemoClaw operations.
+ *
+ * Returns an array of tool definitions that can be passed directly to
+ * OpenAI's `tools` parameter, Vercel AI SDK, or any framework that
+ * accepts the OpenAI tool format.
+ *
+ * @example
+ * ```ts
+ * import { getMemoclawTools } from '@memoclaw/sdk';
+ *
+ * // All tools
+ * const tools = getMemoclawTools();
+ *
+ * // Only store and recall
+ * const tools = getMemoclawTools({ include: ['store_memory', 'recall_memories'] });
+ *
+ * // All except delete
+ * const tools = getMemoclawTools({ exclude: ['delete_memory'] });
+ * ```
+ */
+export function getMemoclawTools(options?: GetToolsOptions): ToolDefinition[] {
+  let tools = [...ALL_TOOLS];
+
+  if (options?.include?.length) {
+    const includeSet = new Set(options.include);
+    tools = tools.filter((t) => includeSet.has(t.function.name));
+  }
+
+  if (options?.exclude?.length) {
+    const excludeSet = new Set(options.exclude);
+    tools = tools.filter((t) => !excludeSet.has(t.function.name));
+  }
+
+  return tools;
+}
+
+/**
+ * Get a single tool definition by name.
+ *
+ * @returns The tool definition, or undefined if not found.
+ */
+export function getMemoclawTool(name: string): ToolDefinition | undefined {
+  return TOOL_MAP.get(name);
+}
+
+/**
+ * Get all available MemoClaw tool names.
+ */
+export function getMemoclawToolNames(): string[] {
+  return ALL_TOOLS.map((t) => t.function.name);
+}
+
+/**
+ * Execute a MemoClaw tool call using the provided client.
+ *
+ * Parses the tool call arguments, dispatches to the appropriate client
+ * method, and returns a formatted result suitable for sending back to
+ * the LLM.
+ *
+ * @example
+ * ```ts
+ * import { MemoClawClient } from '@memoclaw/sdk';
+ * import { executeMemoclawTool } from '@memoclaw/sdk/tools';
+ *
+ * const client = new MemoClawClient({ privateKey: '0x...' });
+ *
+ * // From OpenAI response
+ * const toolCall = response.choices[0].message.tool_calls[0];
+ * const result = await executeMemoclawTool(client, toolCall);
+ *
+ * // Send result back to OpenAI
+ * messages.push({ role: 'tool', ...result });
+ * ```
+ */
+export async function executeMemoclawTool(
+  client: MemoClawClient,
+  toolCall: ToolCall,
+): Promise<ToolResult> {
+  const { name, arguments: rawArgs } = toolCall.function;
+
+  let args: Record<string, unknown>;
+  try {
+    args = JSON.parse(rawArgs);
+  } catch {
+    return {
+      tool_call_id: toolCall.id,
+      name,
+      content: JSON.stringify({ error: 'Invalid JSON in tool call arguments' }),
+      is_error: true,
+    };
+  }
+
+  try {
+    const result = await dispatchTool(client, name, args);
+    return {
+      tool_call_id: toolCall.id,
+      name,
+      content: JSON.stringify(result),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      tool_call_id: toolCall.id,
+      name,
+      content: JSON.stringify({ error: message }),
+      is_error: true,
+    };
+  }
+}
+
+/** @internal Dispatch a tool call to the appropriate client method. */
+async function dispatchTool(
+  client: MemoClawClient,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  switch (name) {
+    case 'store_memory': {
+      const tags = args.tags as string[] | undefined;
+      return client.store({
+        content: args.content as string,
+        importance: args.importance as number | undefined,
+        memory_type: args.memory_type as MemoryType | undefined,
+        namespace: args.namespace as string | undefined,
+        metadata: tags ? { tags } : undefined,
+      });
+    }
+
+    case 'recall_memories': {
+      const tags = args.tags as string[] | undefined;
+      const memoryType = args.memory_type as MemoryType | undefined;
+      return client.recall({
+        query: args.query as string,
+        limit: args.limit as number | undefined,
+        min_similarity: args.min_similarity as number | undefined,
+        namespace: args.namespace as string | undefined,
+        filters: (tags || memoryType)
+          ? { tags, memory_type: memoryType }
+          : undefined,
+      });
+    }
+
+    case 'list_memories': {
+      return client.list({
+        limit: args.limit as number | undefined,
+        offset: args.offset as number | undefined,
+        namespace: args.namespace as string | undefined,
+        tags: args.tags as string[] | undefined,
+        memory_type: args.memory_type as MemoryType | undefined,
+      });
+    }
+
+    case 'delete_memory': {
+      return client.delete(args.id as string);
+    }
+
+    case 'get_memory': {
+      return client.get(args.id as string);
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}


### PR DESCRIPTION
## Summary

Adds OpenAI-compatible tool definitions for the TypeScript SDK, enabling easy integration with OpenAI function calling, Vercel AI SDK, and any framework that accepts the OpenAI tool format.

Fixes #199

## Changes

### New: `src/tools.ts`
- `getMemoclawTools(options?)` — Returns OpenAI-compatible tool definitions with optional include/exclude filtering
- `executeMemoclawTool(client, toolCall)` — Executes a tool call and returns a formatted result
- `getMemoclawTool(name)` — Get a single tool definition by name
- `getMemoclawToolNames()` — List all available tool names

### Tools exposed:
| Tool | Description |
|------|-------------|
| `store_memory` | Store a new memory with importance, type, tags, namespace |
| `recall_memories` | Semantic search with filters |
| `list_memories` | List/paginate memories with filters |
| `delete_memory` | Delete a memory by ID |
| `get_memory` | Retrieve a memory by ID |

### Exports
- All functions/types exported from main entry point
- Subpath export: `@memoclaw/sdk/tools` for tree-shaking

### Tests
- 26 new tests covering tool definitions, schema validation, execution, error handling, and edge cases
- All 304 tests pass, clean TypeScript typecheck

## Usage

```typescript
import { MemoClawClient, getMemoclawTools, executeMemoclawTool } from '@memoclaw/sdk';

const client = new MemoClawClient({ privateKey: '0x...' });
const tools = getMemoclawTools();

// Pass to OpenAI
const response = await openai.chat.completions.create({
  model: 'gpt-4',
  messages,
  tools,
});

// Execute the tool call
const toolCall = response.choices[0].message.tool_calls[0];
const result = await executeMemoclawTool(client, toolCall);
messages.push({ role: 'tool', ...result });
```