### PR TITLE
feat: add TypeScript framework integrations (LangChain.js, Vercel AI SDK)

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -14,6 +14,14 @@
     "./tools": {
       "import": "./dist/tools.js",
       "types": "./dist/tools.d.ts"
+    },
+    "./langchain": {
+      "import": "./dist/integrations/langchain.js",
+      "types": "./dist/integrations/langchain.d.ts"
+    },
+    "./vercel-ai": {
+      "import": "./dist/integrations/vercel-ai.js",
+      "types": "./dist/integrations/vercel-ai.d.ts"
     }
   },
   "files": [

--- a/typescript/src/__tests__/integrations-langchain.test.ts
+++ b/typescript/src/__tests__/integrations-langchain.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoClawClient } from '../index.js';
+import { MemoClawChatMessageHistory, MemoClawRetriever } from '../integrations/langchain.js';
+import type { LangChainMessage } from '../integrations/langchain.js';
+
+const BASE_URL = 'https://api.memoclaw.com';
+const TEST_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+function mockFetch(responses: Array<{ status: number; body?: unknown }>): typeof globalThis.fetch {
+  let callIndex = 0;
+  return vi.fn(async () => {
+    const resp = responses[callIndex] ?? responses[responses.length - 1]!;
+    callIndex++;
+    return {
+      ok: resp.status >= 200 && resp.status < 300,
+      status: resp.status,
+      json: async () => resp.body,
+      headers: { get: () => null },
+    } as unknown as Response;
+  });
+}
+
+function createClient(fetchFn: typeof globalThis.fetch) {
+  return new MemoClawClient({
+    privateKey: TEST_PRIVATE_KEY,
+    baseUrl: BASE_URL,
+    fetch: fetchFn,
+    maxRetries: 1,
+    retryDelay: 1,
+  });
+}
+
+function makeMessage(role: string, content: string): LangChainMessage {
+  return {
+    content,
+    _getType() {
+      if (role === 'user') return 'human';
+      if (role === 'assistant') return 'ai';
+      return role;
+    },
+  };
+}
+
+describe('MemoClawChatMessageHistory', () => {
+  it('getMessages returns messages from MemoClaw list', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 200,
+        body: {
+          memories: [
+            { id: '1', content: 'Hello', metadata: { role: 'user' }, importance: 0.5 },
+            { id: '2', content: 'Hi there', metadata: { role: 'assistant' }, importance: 0.5 },
+          ],
+          total: 2,
+        },
+      },
+    ]);
+
+    const client = createClient(fetchFn);
+    const history = new MemoClawChatMessageHistory({
+      client,
+      sessionId: 'test-session',
+    });
+
+    const messages = await history.getMessages();
+    expect(messages).toHaveLength(2);
+    expect(messages[0]!._getType()).toBe('human');
+    expect(messages[0]!.content).toBe('Hello');
+    expect(messages[1]!._getType()).toBe('ai');
+    expect(messages[1]!.content).toBe('Hi there');
+  });
+
+  it('getMessages paginates through all memories', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 200,
+        body: {
+          memories: Array.from({ length: 100 }, (_, i) => ({
+            id: String(i),
+            content: `Message ${i}`,
+            metadata: { role: 'user' },
+            importance: 0.5,
+          })),
+          total: 150,
+        },
+      },
+      {
+        status: 200,
+        body: {
+          memories: Array.from({ length: 50 }, (_, i) => ({
+            id: String(100 + i),
+            content: `Message ${100 + i}`,
+            metadata: { role: 'user' },
+            importance: 0.5,
+          })),
+          total: 150,
+        },
+      },
+    ]);
+
+    const client = createClient(fetchFn);
+    const history = new MemoClawChatMessageHistory({
+      client,
+      sessionId: 'test-session',
+    });
+
+    const messages = await history.getMessages();
+    expect(messages).toHaveLength(150);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('addMessage stores a message with correct role metadata', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { id: 'mem-1', stored: true, deduplicated: false, tokens_used: 10 } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const history = new MemoClawChatMessageHistory({
+      client,
+      sessionId: 'test-session',
+      namespace: 'test-ns',
+    });
+
+    const msg = makeMessage('user', 'I prefer dark mode');
+    await history.addMessage(msg);
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const call = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const body = JSON.parse(call[1].body);
+    expect(body.content).toBe('I prefer dark mode');
+    expect(body.metadata.role).toBe('user');
+    expect(body.metadata.tags).toEqual(['chat_message']);
+    expect(body.session_id).toBe('test-session');
+    expect(body.namespace).toBe('test-ns');
+  });
+
+  it('addMessages batches messages', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { ids: ['1', '2'], stored: true, count: 2, deduplicated_count: 0, tokens_used: 20 } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const history = new MemoClawChatMessageHistory({
+      client,
+      sessionId: 'test-session',
+    });
+
+    await history.addMessages([
+      makeMessage('user', 'Hello'),
+      makeMessage('assistant', 'Hi!'),
+    ]);
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const call = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const body = JSON.parse(call[1].body);
+    expect(body.memories).toHaveLength(2);
+  });
+
+  it('addMessages skips empty array', async () => {
+    const fetchFn = mockFetch([]);
+    const client = createClient(fetchFn);
+    const history = new MemoClawChatMessageHistory({
+      client,
+      sessionId: 'test-session',
+    });
+
+    await history.addMessages([]);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('clear deletes all session messages', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 200,
+        body: {
+          memories: [
+            { id: 'mem-1', content: 'Hello', metadata: {}, importance: 0.5 },
+            { id: 'mem-2', content: 'World', metadata: {}, importance: 0.5 },
+          ],
+          total: 2,
+        },
+      },
+      { status: 200, body: { results: [{ id: 'mem-1', deleted: true }, { id: 'mem-2', deleted: true }] } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const history = new MemoClawChatMessageHistory({
+      client,
+      sessionId: 'test-session',
+    });
+
+    await history.clear();
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('clear does nothing when no messages exist', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { memories: [], total: 0 } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const history = new MemoClawChatMessageHistory({
+      client,
+      sessionId: 'test-session',
+    });
+
+    await history.clear();
+    expect(fetchFn).toHaveBeenCalledTimes(1); // Only the list call
+  });
+
+  it('uses custom tag', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { memories: [], total: 0 } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const history = new MemoClawChatMessageHistory({
+      client,
+      sessionId: 'test-session',
+      tag: 'custom_tag',
+    });
+
+    await history.getMessages();
+    const call = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const url = call[0] as string;
+    expect(url).toContain('tags=custom_tag');
+  });
+});
+
+describe('MemoClawRetriever', () => {
+  it('invoke returns documents from recall', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 200,
+        body: {
+          memories: [
+            {
+              id: 'mem-1',
+              content: 'User prefers dark mode',
+              similarity: 0.95,
+              importance: 0.8,
+              memory_type: 'preference',
+              namespace: 'default',
+              session_id: null,
+              agent_id: null,
+              created_at: '2026-01-01T00:00:00Z',
+              metadata: { tags: ['ui'] },
+              access_count: 3,
+            },
+          ],
+          total: 1,
+          query_tokens: 5,
+        },
+      },
+    ]);
+
+    const client = createClient(fetchFn);
+    const retriever = new MemoClawRetriever({
+      client,
+      namespace: 'test-ns',
+      topK: 10,
+    });
+
+    const docs = await retriever.invoke('user preferences');
+    expect(docs).toHaveLength(1);
+    expect(docs[0]!.pageContent).toBe('User prefers dark mode');
+    expect(docs[0]!.metadata['id']).toBe('mem-1');
+    expect(docs[0]!.metadata['similarity']).toBe(0.95);
+    expect(docs[0]!.metadata['memory_metadata']).toEqual({ tags: ['ui'] });
+  });
+
+  it('getRelevantDocuments is an alias for invoke', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { memories: [], total: 0, query_tokens: 3 } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const retriever = new MemoClawRetriever({ client });
+
+    const docs = await retriever.getRelevantDocuments('test');
+    expect(docs).toEqual([]);
+  });
+
+  it('passes all options to recall request', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { memories: [], total: 0, query_tokens: 3 } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const retriever = new MemoClawRetriever({
+      client,
+      namespace: 'ns',
+      tags: ['important'],
+      topK: 3,
+      minSimilarity: 0.7,
+      sessionId: 'sess-1',
+      agentId: 'agent-1',
+      includeRelations: true,
+    });
+
+    await retriever.invoke('test query');
+
+    const call = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const body = JSON.parse(call[1].body);
+    expect(body.query).toBe('test query');
+    expect(body.limit).toBe(3);
+    expect(body.namespace).toBe('ns');
+    expect(body.min_similarity).toBe(0.7);
+    expect(body.session_id).toBe('sess-1');
+    expect(body.agent_id).toBe('agent-1');
+    expect(body.include_relations).toBe(true);
+    expect(body.filters).toEqual({ tags: ['important'] });
+  });
+});

--- a/typescript/src/__tests__/integrations-vercel-ai.test.ts
+++ b/typescript/src/__tests__/integrations-vercel-ai.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MemoClawClient } from '../index.js';
+import { createMemoryContext, createMemoryTools } from '../integrations/vercel-ai.js';
+
+const BASE_URL = 'https://api.memoclaw.com';
+const TEST_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+function mockFetch(responses: Array<{ status: number; body?: unknown }>): typeof globalThis.fetch {
+  let callIndex = 0;
+  return vi.fn(async () => {
+    const resp = responses[callIndex] ?? responses[responses.length - 1]!;
+    callIndex++;
+    return {
+      ok: resp.status >= 200 && resp.status < 300,
+      status: resp.status,
+      json: async () => resp.body,
+      headers: { get: () => null },
+    } as unknown as Response;
+  });
+}
+
+function createClient(fetchFn: typeof globalThis.fetch) {
+  return new MemoClawClient({
+    privateKey: TEST_PRIVATE_KEY,
+    baseUrl: BASE_URL,
+    fetch: fetchFn,
+    maxRetries: 1,
+    retryDelay: 1,
+  });
+}
+
+describe('createMemoryContext', () => {
+  it('getSystemPrompt returns formatted memories', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 200,
+        body: {
+          memories: [
+            {
+              id: '1',
+              content: 'User likes dark mode',
+              similarity: 0.95,
+              importance: 0.8,
+              memory_type: 'preference',
+              namespace: 'default',
+              session_id: null,
+              agent_id: null,
+              created_at: '2026-01-01T00:00:00Z',
+              metadata: {},
+              access_count: 1,
+            },
+            {
+              id: '2',
+              content: 'User prefers TypeScript',
+              similarity: 0.88,
+              importance: 0.7,
+              memory_type: 'preference',
+              namespace: 'default',
+              session_id: null,
+              agent_id: null,
+              created_at: '2026-01-02T00:00:00Z',
+              metadata: {},
+              access_count: 2,
+            },
+          ],
+          total: 2,
+          query_tokens: 5,
+        },
+      },
+    ]);
+
+    const client = createClient(fetchFn);
+    const ctx = createMemoryContext(client, { namespace: 'test' });
+
+    const prompt = await ctx.getSystemPrompt('user preferences');
+    expect(prompt).toContain('## Relevant Memories');
+    expect(prompt).toContain('95% match');
+    expect(prompt).toContain('User likes dark mode');
+    expect(prompt).toContain('88% match');
+    expect(prompt).toContain('User prefers TypeScript');
+  });
+
+  it('getSystemPrompt with preamble prepends it', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 200,
+        body: {
+          memories: [
+            {
+              id: '1', content: 'Test memory', similarity: 0.9,
+              importance: 0.5, memory_type: 'general', namespace: 'default',
+              session_id: null, agent_id: null, created_at: '2026-01-01T00:00:00Z',
+              metadata: {}, access_count: 1,
+            },
+          ],
+          total: 1,
+          query_tokens: 3,
+        },
+      },
+    ]);
+
+    const client = createClient(fetchFn);
+    const ctx = createMemoryContext(client);
+
+    const prompt = await ctx.getSystemPrompt('test', 'You are a helpful assistant.');
+    expect(prompt).toMatch(/^You are a helpful assistant\./);
+    expect(prompt).toContain('## Relevant Memories');
+  });
+
+  it('getSystemPrompt returns empty string when no memories and no preamble', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { memories: [], total: 0, query_tokens: 3 } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const ctx = createMemoryContext(client);
+
+    const prompt = await ctx.getSystemPrompt('test');
+    expect(prompt).toBe('');
+  });
+
+  it('getSystemPrompt returns preamble when no memories found', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { memories: [], total: 0, query_tokens: 3 } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const ctx = createMemoryContext(client);
+
+    const prompt = await ctx.getSystemPrompt('test', 'You are a helpful assistant.');
+    expect(prompt).toBe('You are a helpful assistant.');
+  });
+
+  it('recall returns raw memories', async () => {
+    const memories = [
+      {
+        id: '1', content: 'Test', similarity: 0.9, importance: 0.5,
+        memory_type: 'general', namespace: 'default', session_id: null,
+        agent_id: null, created_at: '2026-01-01T00:00:00Z', metadata: {},
+        access_count: 1,
+      },
+    ];
+
+    const fetchFn = mockFetch([
+      { status: 200, body: { memories, total: 1, query_tokens: 3 } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const ctx = createMemoryContext(client, { namespace: 'ns', maxMemories: 5 });
+
+    const result = await ctx.recall('test');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.content).toBe('Test');
+  });
+
+  it('storeMessage stores with correct metadata', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { id: 'mem-1', stored: true, deduplicated: false, tokens_used: 10 } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const ctx = createMemoryContext(client, {
+      namespace: 'test-ns',
+      sessionId: 'sess-1',
+      agentId: 'agent-1',
+    });
+
+    const id = await ctx.storeMessage('user', 'I like TypeScript', 0.8);
+    expect(id).toBe('mem-1');
+
+    const call = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const body = JSON.parse(call[1].body);
+    expect(body.content).toBe('I like TypeScript');
+    expect(body.metadata.role).toBe('user');
+    expect(body.metadata.tags).toEqual(['conversation']);
+    expect(body.namespace).toBe('test-ns');
+    expect(body.session_id).toBe('sess-1');
+    expect(body.agent_id).toBe('agent-1');
+    expect(body.importance).toBe(0.8);
+  });
+
+  it('store stores arbitrary memory', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { id: 'mem-2', stored: true, deduplicated: false, tokens_used: 10 } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const ctx = createMemoryContext(client, { namespace: 'test-ns' });
+
+    const id = await ctx.store('Important fact', { importance: 1.0, metadata: { tags: ['fact'] } });
+    expect(id).toBe('mem-2');
+  });
+});
+
+describe('createMemoryTools', () => {
+  it('returns store_memory and recall_memories tools', () => {
+    const fetchFn = mockFetch([]);
+    const client = createClient(fetchFn);
+
+    const tools = createMemoryTools(client);
+    expect(tools).toHaveProperty('store_memory');
+    expect(tools).toHaveProperty('recall_memories');
+    expect(tools['store_memory']!.description).toBeTruthy();
+    expect(tools['recall_memories']!.description).toBeTruthy();
+    expect(tools['store_memory']!.parameters.type).toBe('object');
+    expect(tools['recall_memories']!.parameters.type).toBe('object');
+  });
+
+  it('store_memory tool stores a memory', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { id: 'mem-1', stored: true, deduplicated: false, tokens_used: 10 } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const tools = createMemoryTools(client, { namespace: 'tool-ns' });
+
+    const result = await tools['store_memory']!.execute({
+      content: 'User prefers Python',
+      importance: 0.9,
+      tags: ['preference'],
+    });
+
+    expect(result).toEqual({ id: 'mem-1', stored: true });
+
+    const call = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const body = JSON.parse(call[1].body);
+    expect(body.content).toBe('User prefers Python');
+    expect(body.importance).toBe(0.9);
+    expect(body.namespace).toBe('tool-ns');
+    expect(body.metadata.tags).toEqual(['preference']);
+  });
+
+  it('recall_memories tool searches memories', async () => {
+    const fetchFn = mockFetch([
+      {
+        status: 200,
+        body: {
+          memories: [
+            {
+              id: '1', content: 'User prefers Python', similarity: 0.92,
+              importance: 0.9, memory_type: 'preference', namespace: 'default',
+              session_id: null, agent_id: null, created_at: '2026-01-01T00:00:00Z',
+              metadata: {}, access_count: 1,
+            },
+          ],
+          total: 1,
+          query_tokens: 3,
+        },
+      },
+    ]);
+
+    const client = createClient(fetchFn);
+    const tools = createMemoryTools(client);
+
+    const result = await tools['recall_memories']!.execute({
+      query: 'language preferences',
+      limit: 3,
+    });
+
+    expect(result).toEqual([
+      {
+        content: 'User prefers Python',
+        similarity: 0.92,
+        importance: 0.9,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ]);
+  });
+
+  it('recall_memories defaults to limit 5', async () => {
+    const fetchFn = mockFetch([
+      { status: 200, body: { memories: [], total: 0, query_tokens: 3 } },
+    ]);
+
+    const client = createClient(fetchFn);
+    const tools = createMemoryTools(client);
+
+    await tools['recall_memories']!.execute({ query: 'test' });
+
+    const call = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const body = JSON.parse(call[1].body);
+    expect(body.limit).toBe(5);
+  });
+});

--- a/typescript/src/integrations/langchain.ts
+++ b/typescript/src/integrations/langchain.ts
@@ -1,0 +1,312 @@
+/**
+ * LangChain.js integration for MemoClaw.
+ *
+ * Provides:
+ * - {@link MemoClawChatMessageHistory} — LangChain-compatible chat message history
+ *   backed by MemoClaw's memory API.
+ * - {@link MemoClawRetriever} — LangChain-compatible retriever that performs semantic
+ *   recall over stored memories.
+ *
+ * Install peer dependencies:
+ * ```bash
+ * npm install @langchain/core
+ * ```
+ *
+ * @example Chat history
+ * ```typescript
+ * import { MemoClawClient } from '@memoclaw/sdk';
+ * import { MemoClawChatMessageHistory } from '@memoclaw/sdk/langchain';
+ *
+ * const client = await MemoClawClient.create({ privateKey: '0x...' });
+ * const history = new MemoClawChatMessageHistory({ client, sessionId: 'chat-42' });
+ * await history.addMessage(new HumanMessage('I prefer dark mode'));
+ * const messages = await history.getMessages();
+ * ```
+ *
+ * @example Retriever
+ * ```typescript
+ * import { MemoClawRetriever } from '@memoclaw/sdk/langchain';
+ *
+ * const retriever = new MemoClawRetriever({ client, namespace: 'project-x' });
+ * const docs = await retriever.invoke('user preferences');
+ * ```
+ *
+ * @module
+ */
+
+import type { MemoClawClient } from '../client.js';
+import type { StoreRequest } from '../types.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+// We use minimal interfaces instead of importing from @langchain/core
+// so this module compiles without the peer dependency installed.
+
+/** Minimal LangChain BaseMessage interface. */
+export interface LangChainMessage {
+  content: string | Array<{ type: string; text?: string }>;
+  _getType(): string;
+}
+
+/** Minimal LangChain Document interface. */
+export interface LangChainDocument {
+  pageContent: string;
+  metadata: Record<string, unknown>;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function messageToRole(message: LangChainMessage): string {
+  const type = message._getType();
+  if (type === 'human') return 'user';
+  if (type === 'ai') return 'assistant';
+  if (type === 'system') return 'system';
+  return type;
+}
+
+function contentToString(content: string | Array<{ type: string; text?: string }>): string {
+  if (typeof content === 'string') return content;
+  return content
+    .filter((c) => c.type === 'text' && c.text)
+    .map((c) => c.text!)
+    .join('');
+}
+
+/** Create a LangChain-style message object (without requiring @langchain/core). */
+function createMessage(role: string, content: string): LangChainMessage {
+  return {
+    content,
+    _getType: () => (role === 'user' ? 'human' : role === 'assistant' ? 'ai' : role),
+  };
+}
+
+/** Create a LangChain-style Document object (without requiring @langchain/core). */
+function createDocument(pageContent: string, metadata: Record<string, unknown>): LangChainDocument {
+  return { pageContent, metadata };
+}
+
+// ── Chat Message History ────────────────────────────────────────────────────
+
+export interface MemoClawChatMessageHistoryOptions {
+  /** Configured MemoClawClient instance. */
+  client: MemoClawClient;
+  /** Unique session identifier. Maps to MemoClaw's session_id parameter. */
+  sessionId: string;
+  /** Optional MemoClaw namespace for isolation. */
+  namespace?: string;
+  /** Optional agent identifier. */
+  agentId?: string;
+  /** Tag used to identify chat messages (default: "chat_message"). */
+  tag?: string;
+}
+
+/**
+ * LangChain-compatible chat message history backed by MemoClaw.
+ *
+ * Stores each message as an individual memory with a configurable tag.
+ * Messages are stored via `client.store()` and retrieved via `client.list()`.
+ *
+ * Implements the same interface as LangChain's `BaseChatMessageHistory`
+ * via duck-typing, so it works with LangChain APIs without requiring
+ * `@langchain/core` at build time.
+ */
+export class MemoClawChatMessageHistory {
+  private readonly _client: MemoClawClient;
+  private readonly _sessionId: string;
+  private readonly _namespace?: string;
+  private readonly _agentId?: string;
+  private readonly _tag: string;
+
+  constructor(options: MemoClawChatMessageHistoryOptions) {
+    this._client = options.client;
+    this._sessionId = options.sessionId;
+    this._namespace = options.namespace;
+    this._agentId = options.agentId;
+    this._tag = options.tag ?? 'chat_message';
+  }
+
+  /** Retrieve all messages for this session from MemoClaw. */
+  async getMessages(): Promise<LangChainMessage[]> {
+    const result: LangChainMessage[] = [];
+    let offset = 0;
+    const batchSize = 100;
+
+    while (true) {
+      const page = await this._client.list({
+        session_id: this._sessionId,
+        namespace: this._namespace,
+        agent_id: this._agentId,
+        tags: [this._tag],
+        limit: batchSize,
+        offset,
+      });
+
+      for (const memory of page.memories) {
+        const meta = memory.metadata ?? {};
+        const role = String(meta['role'] ?? 'user');
+        result.push(createMessage(role, memory.content));
+      }
+
+      offset += page.memories.length;
+      if (offset >= page.total || page.memories.length === 0) break;
+    }
+
+    return result;
+  }
+
+  /** Store a single message in MemoClaw. */
+  async addMessage(message: LangChainMessage): Promise<void> {
+    const role = messageToRole(message);
+    const content = contentToString(message.content);
+    const request: StoreRequest = {
+      content,
+      metadata: { tags: [this._tag], role },
+      session_id: this._sessionId,
+    };
+    if (this._namespace) request.namespace = this._namespace;
+    if (this._agentId) request.agent_id = this._agentId;
+    await this._client.store(request);
+  }
+
+  /** Store multiple messages in MemoClaw using batch storage. */
+  async addMessages(messages: LangChainMessage[]): Promise<void> {
+    if (messages.length === 0) return;
+
+    const items: StoreRequest[] = messages.map((message) => {
+      const role = messageToRole(message);
+      const content = contentToString(message.content);
+      const req: StoreRequest = {
+        content,
+        metadata: { tags: [this._tag], role },
+        session_id: this._sessionId,
+      };
+      if (this._namespace) req.namespace = this._namespace;
+      if (this._agentId) req.agent_id = this._agentId;
+      return req;
+    });
+
+    // Batch in chunks of 100
+    for (let i = 0; i < items.length; i += 100) {
+      const chunk = items.slice(i, i + 100);
+      await this._client.storeBatch(chunk);
+    }
+  }
+
+  /** Delete all messages for this session from MemoClaw. */
+  async clear(): Promise<void> {
+    const ids: string[] = [];
+    let offset = 0;
+    const batchSize = 100;
+
+    while (true) {
+      const page = await this._client.list({
+        session_id: this._sessionId,
+        namespace: this._namespace,
+        agent_id: this._agentId,
+        tags: [this._tag],
+        limit: batchSize,
+        offset,
+      });
+
+      ids.push(...page.memories.map((m) => m.id));
+      offset += page.memories.length;
+      if (offset >= page.total || page.memories.length === 0) break;
+    }
+
+    if (ids.length > 0) {
+      await this._client.deleteBatch(ids);
+    }
+  }
+}
+
+// ── Retriever ───────────────────────────────────────────────────────────────
+
+export interface MemoClawRetrieverOptions {
+  /** Configured MemoClawClient instance. */
+  client: MemoClawClient;
+  /** Optional MemoClaw namespace filter. */
+  namespace?: string;
+  /** Optional tag filter for recall. */
+  tags?: string[];
+  /** Maximum number of memories to return (default: 5). */
+  topK?: number;
+  /** Minimum similarity threshold (0.0–1.0). */
+  minSimilarity?: number;
+  /** Optional session ID filter. */
+  sessionId?: string;
+  /** Optional agent ID filter. */
+  agentId?: string;
+  /** Whether to include related memories. */
+  includeRelations?: boolean;
+}
+
+/**
+ * LangChain-compatible retriever that performs semantic recall over MemoClaw memories.
+ *
+ * Each recalled memory is returned as a LangChain-compatible Document with the memory
+ * content as `pageContent` and memory metadata in `metadata`.
+ */
+export class MemoClawRetriever {
+  private readonly _client: MemoClawClient;
+  private readonly _namespace?: string;
+  private readonly _tags?: string[];
+  private readonly _topK: number;
+  private readonly _minSimilarity?: number;
+  private readonly _sessionId?: string;
+  private readonly _agentId?: string;
+  private readonly _includeRelations: boolean;
+
+  constructor(options: MemoClawRetrieverOptions) {
+    this._client = options.client;
+    this._namespace = options.namespace;
+    this._tags = options.tags;
+    this._topK = options.topK ?? 5;
+    this._minSimilarity = options.minSimilarity;
+    this._sessionId = options.sessionId;
+    this._agentId = options.agentId;
+    this._includeRelations = options.includeRelations ?? false;
+  }
+
+  /**
+   * Retrieve relevant documents from MemoClaw via semantic recall.
+   * Compatible with LangChain's retriever interface.
+   */
+  async invoke(query: string): Promise<LangChainDocument[]> {
+    const response = await this._client.recall({
+      query,
+      limit: this._topK,
+      namespace: this._namespace,
+      min_similarity: this._minSimilarity,
+      session_id: this._sessionId,
+      agent_id: this._agentId,
+      include_relations: this._includeRelations || undefined,
+      filters: this._tags ? { tags: this._tags } : undefined,
+    });
+
+    return response.memories.map((memory) => {
+      const metadata: Record<string, unknown> = {
+        id: memory.id,
+        similarity: memory.similarity,
+        importance: memory.importance,
+        memory_type: memory.memory_type,
+        namespace: memory.namespace,
+        created_at: memory.created_at,
+      };
+      if (memory.metadata) {
+        metadata['memory_metadata'] = memory.metadata;
+      }
+      if (memory.session_id) {
+        metadata['session_id'] = memory.session_id;
+      }
+      if (memory.agent_id) {
+        metadata['agent_id'] = memory.agent_id;
+      }
+
+      return createDocument(memory.content, metadata);
+    });
+  }
+
+  /** Alias for invoke() — matches LangChain's getRelevantDocuments pattern. */
+  async getRelevantDocuments(query: string): Promise<LangChainDocument[]> {
+    return this.invoke(query);
+  }
+}

--- a/typescript/src/integrations/vercel-ai.ts
+++ b/typescript/src/integrations/vercel-ai.ts
@@ -1,0 +1,280 @@
+/**
+ * Vercel AI SDK integration for MemoClaw.
+ *
+ * Provides helper utilities for using MemoClaw with the Vercel AI SDK
+ * (`ai` package) for `generateText` and `streamText` workflows.
+ *
+ * @example Basic context injection
+ * ```typescript
+ * import { MemoClawClient } from '@memoclaw/sdk';
+ * import { createMemoryContext } from '@memoclaw/sdk/vercel-ai';
+ * import { generateText } from 'ai';
+ *
+ * const client = await MemoClawClient.create({ privateKey: '0x...' });
+ * const memoryContext = createMemoryContext(client, { namespace: 'my-project' });
+ *
+ * const { text } = await generateText({
+ *   model: yourModel,
+ *   system: await memoryContext.getSystemPrompt('Tell me about the user'),
+ *   prompt: 'What do you know about my preferences?',
+ * });
+ *
+ * // After the conversation, store new memories
+ * await memoryContext.storeMessage('user', 'I prefer dark mode');
+ * await memoryContext.storeMessage('assistant', text);
+ * ```
+ *
+ * @module
+ */
+
+import type { MemoClawClient } from '../client.js';
+import type { RecallMemory, StoreRequest } from '../types.js';
+
+// ── Memory Context ──────────────────────────────────────────────────────────
+
+export interface MemoryContextOptions {
+  /** Optional MemoClaw namespace for isolation. */
+  namespace?: string;
+  /** Optional session ID for conversation scoping. */
+  sessionId?: string;
+  /** Optional agent ID. */
+  agentId?: string;
+  /** Maximum memories to include in context (default: 10). */
+  maxMemories?: number;
+  /** Minimum similarity threshold for recall (default: 0.5). */
+  minSimilarity?: number;
+  /** Whether to include related memories (default: false). */
+  includeRelations?: boolean;
+}
+
+export interface MemoryContext {
+  /**
+   * Recall memories relevant to a query and format them as a system prompt section.
+   *
+   * @param query - The query to search for relevant memories
+   * @param preamble - Optional text to prepend before the memories section
+   * @returns A formatted string with recalled memories ready for a system prompt
+   */
+  getSystemPrompt(query: string, preamble?: string): Promise<string>;
+
+  /**
+   * Recall raw memories relevant to a query.
+   *
+   * @param query - The query to search for relevant memories
+   * @returns Array of recalled memories with metadata
+   */
+  recall(query: string): Promise<RecallMemory[]>;
+
+  /**
+   * Store a conversation message as a memory.
+   *
+   * @param role - The role of the message sender ('user', 'assistant', 'system')
+   * @param content - The message content
+   * @param importance - Optional importance score (0.0–1.0)
+   * @returns The stored memory ID
+   */
+  storeMessage(role: string, content: string, importance?: number): Promise<string>;
+
+  /**
+   * Store an arbitrary memory.
+   *
+   * @param content - The memory content
+   * @param options - Additional store options
+   * @returns The stored memory ID
+   */
+  store(content: string, storeOptions?: Partial<StoreRequest>): Promise<string>;
+}
+
+/**
+ * Create a memory context helper for Vercel AI SDK workflows.
+ *
+ * Provides methods to recall relevant memories and format them as
+ * system prompts, as well as store new conversation messages.
+ */
+export function createMemoryContext(client: MemoClawClient, options: MemoryContextOptions = {}): MemoryContext {
+  const {
+    namespace,
+    sessionId,
+    agentId,
+    maxMemories = 10,
+    minSimilarity = 0.5,
+    includeRelations = false,
+  } = options;
+
+  return {
+    async getSystemPrompt(query: string, preamble?: string): Promise<string> {
+      const response = await client.recall({
+        query,
+        limit: maxMemories,
+        min_similarity: minSimilarity,
+        namespace,
+        session_id: sessionId,
+        agent_id: agentId,
+        include_relations: includeRelations || undefined,
+      });
+
+      if (response.memories.length === 0) {
+        return preamble ?? '';
+      }
+
+      const memoryLines = response.memories.map((m, i) =>
+        `${i + 1}. [${(m.similarity * 100).toFixed(0)}% match] ${m.content}`
+      );
+
+      const memorySection = [
+        '## Relevant Memories',
+        '',
+        ...memoryLines,
+      ].join('\n');
+
+      return preamble
+        ? `${preamble}\n\n${memorySection}`
+        : memorySection;
+    },
+
+    async recall(query: string): Promise<RecallMemory[]> {
+      const response = await client.recall({
+        query,
+        limit: maxMemories,
+        min_similarity: minSimilarity,
+        namespace,
+        session_id: sessionId,
+        agent_id: agentId,
+        include_relations: includeRelations || undefined,
+      });
+      return response.memories;
+    },
+
+    async storeMessage(role: string, content: string, importance?: number): Promise<string> {
+      const request: StoreRequest = {
+        content,
+        metadata: { tags: ['conversation'], role },
+        session_id: sessionId,
+        namespace,
+        agent_id: agentId,
+        importance,
+      };
+      const result = await client.store(request);
+      return result.id;
+    },
+
+    async store(content: string, storeOptions?: Partial<StoreRequest>): Promise<string> {
+      const request: StoreRequest = {
+        content,
+        namespace,
+        session_id: sessionId,
+        agent_id: agentId,
+        ...storeOptions,
+      };
+      const result = await client.store(request);
+      return result.id;
+    },
+  };
+}
+
+// ── Tool Definition Types ───────────────────────────────────────────────────
+// Minimal type definitions for Vercel AI SDK tool compatibility
+// without requiring `ai` or `zod` as build-time dependencies.
+
+/** A tool definition compatible with Vercel AI SDK's tool interface. */
+export interface MemoryToolDefinition {
+  description: string;
+  parameters: {
+    type: 'object';
+    properties: Record<string, {
+      type: string;
+      description?: string;
+      minimum?: number;
+      maximum?: number;
+      items?: { type: string };
+    }>;
+    required: string[];
+  };
+  execute: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+export interface MemoryToolsOptions {
+  /** Optional MemoClaw namespace. */
+  namespace?: string;
+  /** Optional session ID. */
+  sessionId?: string;
+  /** Optional agent ID. */
+  agentId?: string;
+}
+
+/**
+ * Create tool definitions for MemoClaw that work with Vercel AI SDK.
+ *
+ * Returns an object with `store_memory` and `recall_memories` tools
+ * with JSON Schema parameters (compatible with `generateText`/`streamText`).
+ *
+ * For native Vercel AI SDK `tool()` integration with Zod schemas,
+ * you can wrap these yourself or use the JSON Schema definitions directly.
+ */
+export function createMemoryTools(
+  client: MemoClawClient,
+  options: MemoryToolsOptions = {},
+): Record<string, MemoryToolDefinition> {
+  const { namespace, sessionId, agentId } = options;
+
+  return {
+    store_memory: {
+      description: 'Store a piece of information as a persistent memory for later recall.',
+      parameters: {
+        type: 'object',
+        properties: {
+          content: { type: 'string', description: 'The content to store as a memory' },
+          importance: { type: 'number', description: 'Importance score from 0.0 to 1.0', minimum: 0, maximum: 1 },
+          tags: { type: 'array', description: 'Tags for categorizing the memory', items: { type: 'string' } },
+        },
+        required: ['content'],
+      },
+      execute: async (args: Record<string, unknown>) => {
+        const content = args['content'] as string;
+        const importance = args['importance'] as number | undefined;
+        const tags = args['tags'] as string[] | undefined;
+        const request: StoreRequest = {
+          content,
+          importance,
+          namespace,
+          session_id: sessionId,
+          agent_id: agentId,
+        };
+        if (tags?.length) {
+          request.metadata = { tags };
+        }
+        const result = await client.store(request);
+        return { id: result.id, stored: result.stored };
+      },
+    },
+
+    recall_memories: {
+      description: 'Search for relevant memories using semantic similarity.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'The search query to find relevant memories' },
+          limit: { type: 'number', description: 'Maximum number of results (default: 5)', minimum: 1, maximum: 50 },
+        },
+        required: ['query'],
+      },
+      execute: async (args: Record<string, unknown>) => {
+        const query = args['query'] as string;
+        const limit = (args['limit'] as number | undefined) ?? 5;
+        const response = await client.recall({
+          query,
+          limit,
+          namespace,
+          session_id: sessionId,
+          agent_id: agentId,
+        });
+        return response.memories.map((m) => ({
+          content: m.content,
+          similarity: m.similarity,
+          importance: m.importance,
+          created_at: m.created_at,
+        }));
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds two new entry points to the TypeScript SDK for framework integrations, closing the competitive gap with Mem0 and Zep.

### `@memoclaw/sdk/langchain` (closes #206)

- **MemoClawChatMessageHistory** — LangChain-compatible chat message history backed by MemoClaw
  - `getMessages()`, `addMessage()`, `addMessages()`, `clear()`
  - Automatic pagination for large histories
  - Configurable tags, namespaces, session/agent IDs
- **MemoClawRetriever** — Semantic recall retriever
  - `invoke(query)` and `getRelevantDocuments(query)`
  - Returns LangChain-compatible Document objects with full memory metadata

### `@memoclaw/sdk/vercel-ai`

- **createMemoryContext()** — Helper for `generateText`/`streamText` workflows
  - `getSystemPrompt(query)` — Recall + format memories as system prompt section
  - `recall(query)` — Raw memory retrieval
  - `storeMessage(role, content)` — Store conversation turns
  - `store(content)` — Store arbitrary memories
- **createMemoryTools()** — JSON Schema tool definitions
  - `store_memory` and `recall_memories` tools
  - Compatible with Vercel AI SDK tool calling patterns

### Design Decisions

- **No build-time dependencies** on `@langchain/core`, `ai`, or `zod` — uses minimal duck-typed interfaces
- **Mirrors Python SDK patterns** — consistent API design across SDKs
- **22 new tests** with full coverage

Fixes #206