### PR TITLE
fix: validate importance and content length per item in updateBatch/update_batch

### DIFF
--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -723,6 +723,10 @@ class MemoClaw:
         for item in items:
             if "id" not in item or not item["id"]:
                 raise ValueError("Each update must include a non-empty 'id'")
+            if "content" in item and item["content"] is not None:
+                _validate_content_length(item["content"])
+            if "importance" in item and item["importance"] is not None:
+                _validate_importance(item["importance"])
         data = self._run_request(
             "PATCH", "/v1/memories/batch", json={"updates": items}, timeout=timeout
         )
@@ -2080,6 +2084,10 @@ class AsyncMemoClaw:
         for item in items:
             if "id" not in item or not item["id"]:
                 raise ValueError("Each update must include a non-empty 'id'")
+            if "content" in item and item["content"] is not None:
+                _validate_content_length(item["content"])
+            if "importance" in item and item["importance"] is not None:
+                _validate_importance(item["importance"])
         data = await self._run_request(
             "PATCH", "/v1/memories/batch", json={"updates": items}, timeout=timeout
         )

--- a/python/tests/test_new_endpoints.py
+++ b/python/tests/test_new_endpoints.py
@@ -298,6 +298,28 @@ class TestUpdateBatch:
         with pytest.raises(ValueError, match="non-empty 'id'"):
             client.update_batch([{"importance": 0.5}])
 
+    def test_importance_too_high_raises(self, client):
+        with pytest.raises(ValueError, match="importance must be between"):
+            client.update_batch([{"id": "mem-1", "importance": 1.5}])
+
+    def test_importance_negative_raises(self, client):
+        with pytest.raises(ValueError, match="importance must be between"):
+            client.update_batch([{"id": "mem-1", "importance": -0.1}])
+
+    def test_content_too_long_raises(self, client):
+        with pytest.raises(ValueError, match="exceeds the 8192 character limit"):
+            client.update_batch([{"id": "mem-1", "content": "x" * 8193}])
+
+    @pytest.mark.asyncio
+    async def test_async_importance_too_high_raises(self, async_client):
+        with pytest.raises(ValueError, match="importance must be between"):
+            await async_client.update_batch([{"id": "mem-1", "importance": 1.5}])
+
+    @pytest.mark.asyncio
+    async def test_async_content_too_long_raises(self, async_client):
+        with pytest.raises(ValueError, match="exceeds the 8192 character limit"):
+            await async_client.update_batch([{"id": "mem-1", "content": "x" * 8193}])
+
     @respx.mock
     @pytest.mark.asyncio
     async def test_async(self, async_client):

--- a/typescript/src/__tests__/new-endpoints.test.ts
+++ b/typescript/src/__tests__/new-endpoints.test.ts
@@ -206,6 +206,27 @@ describe('updateBatch', () => {
     const client = createClient(vi.fn());
     await expect(client.updateBatch([{ id: '', importance: 0.5 }])).rejects.toThrow('non-empty id');
   });
+
+  it('should throw on importance > 1 per item', async () => {
+    const client = createClient(vi.fn());
+    await expect(
+      client.updateBatch([{ id: 'mem-1', importance: 1.5 }]),
+    ).rejects.toThrow('importance must be between 0.0 and 1.0');
+  });
+
+  it('should throw on importance < 0 per item', async () => {
+    const client = createClient(vi.fn());
+    await expect(
+      client.updateBatch([{ id: 'mem-1', importance: -0.1 }]),
+    ).rejects.toThrow('importance must be between 0.0 and 1.0');
+  });
+
+  it('should throw when content exceeds 8192 chars per item', async () => {
+    const client = createClient(vi.fn());
+    await expect(
+      client.updateBatch([{ id: 'mem-1', content: 'x'.repeat(8193) }]),
+    ).rejects.toThrow('content exceeds the 8192 character limit');
+  });
 });
 
 describe('coreMemories', () => {

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -687,6 +687,12 @@ export class MemoClawClient {
       if (!u.id?.trim()) {
         throw new Error('All updates must have a non-empty id');
       }
+      if (u.content !== undefined && u.content.length > MAX_CONTENT_LENGTH) {
+        throw new Error(`content exceeds the ${MAX_CONTENT_LENGTH} character limit. Split into smaller memories or summarize.`);
+      }
+      if (u.importance !== undefined && (u.importance < 0 || u.importance > 1)) {
+        throw new Error('importance must be between 0.0 and 1.0');
+      }
     }
     return this.request<UpdateBatchResponse>(
       'PATCH', '/v1/memories/batch',


### PR DESCRIPTION
## Summary

Fixes the validation gap reported in #209.

Both `updateBatch` (TypeScript) and `update_batch` (Python sync + async) now validate each update item for:
- **importance** outside `[0.0, 1.0]` → raises an error
- **content** exceeding 8 192 characters → raises an error

This makes batch updates consistent with the single-item `update()` method, which already performed these checks.

## Changes

| File | Change |
|------|--------|
| `typescript/src/client.ts` | Added per-item importance and content-length validation in `updateBatch` |
| `python/src/memoclaw/client.py` | Added per-item validation in sync and async `update_batch` |
| `typescript/src/__tests__/new-endpoints.test.ts` | 3 new tests |
| `python/tests/test_new_endpoints.py` | 5 new tests (sync + async) |

## Tests

All existing tests continue to pass:
- TypeScript: **339 tests passed** (3 new)
- Python: **453 tests passed** (5 new)

Fixes #209