### PR TITLE
feat(python): add pool health + warm pool controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to memoclaw-sdk will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.0] - 2026-03-19
+
+### Features
+- **Pool health telemetry** — `MemoClaw.pool_health()` / `AsyncMemoClaw.pool_health()` expose active/idle/max connection stats for debugging latency-sensitive workloads (#215)
+- **Warm-up toggle** — new `warm_pool` flag (sync constructor + async factory) plus `warm_pool()` helpers to pre-establish TCP/TLS connections (#215)
+- **Connection recycling control** — `pool_recycle_seconds` forwards to httpx keepalive expiry so stale sockets are churned proactively (#215)
+- **Docs/tests** — README describes the new knobs and regression tests guard warm-up + health reporting behaviors (#215)
+
 ## [1.0.0] - 2026-03-11
 
 ### Breaking Changes

--- a/python/README.md
+++ b/python/README.md
@@ -132,6 +132,20 @@ client = MemoClaw(
 )
 ```
 
+### Connection pooling controls
+
+```python
+client = MemoClaw(
+    private_key="0x...",
+    warm_pool=True,                    # eager TCP/TLS warm-up on init
+    pool_recycle_seconds=300,          # recycle idle sockets every 5 minutes
+)
+print(client.pool_health())           # {"active_connections": 0, ...}
+```
+
+For async workflows use `await AsyncMemoClaw.create(..., warm_pool=True)` and
+`await client.warm_pool()` to refresh the pool on demand.
+
 ## OpenClaw Integration
 
 MemoClaw is the recommended memory layer for [OpenClaw](https://openclaw.com) agents. Replace flat `memory/*.md` files with semantic search:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memoclaw"
-version = "1.0.0"
+version = "1.1.0"
 description = "Official Python SDK for the MemoClaw memory API"
 readme = "README.md"
 license = "MIT"

--- a/python/src/memoclaw/__init__.py
+++ b/python/src/memoclaw/__init__.py
@@ -1,6 +1,6 @@
 """MemoClaw Python SDK — semantic memory for AI agents."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 from .builders import MemoryBuilder, RecallBuilder
 from .client import AsyncMemoClaw, MemoClaw

--- a/python/src/memoclaw/_client.py
+++ b/python/src/memoclaw/_client.py
@@ -6,7 +6,7 @@ import json as _json
 import logging
 import random
 import time
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
 import httpx
 from eth_account import Account
@@ -83,6 +83,17 @@ def configure_sdk_logging(
 DEFAULT_BASE_URL = "https://api.memoclaw.com"
 DEFAULT_TIMEOUT = 30.0
 DEFAULT_MAX_RETRIES = 2
+
+
+class PoolHealth(TypedDict):
+    """Lightweight snapshot of the underlying httpx connection pool."""
+
+    active_connections: int
+    idle_connections: int
+    max_connections: int
+    max_keepalive_connections: int
+    recycle_seconds: float | None
+
 
 def _sdk_user_agent() -> str:
     """Build User-Agent string with SDK version."""
@@ -161,6 +172,7 @@ class _SyncHTTPClient:
         max_retries: int = DEFAULT_MAX_RETRIES,
         pool_max_connections: int = DEFAULT_POOL_MAX_CONNECTIONS,
         pool_max_keepalive: int = DEFAULT_POOL_MAX_KEEPALIVE_CONNECTIONS,
+        pool_recycle_seconds: float | None = None,
         wallet_address: str | None = None,
     ) -> None:
         if private_key is not None:
@@ -177,13 +189,71 @@ class _SyncHTTPClient:
         self._timeout = timeout
         self._max_retries = max_retries
         self._user_agent = _sdk_user_agent()
+        self._pool_max_connections = pool_max_connections
+        self._pool_max_keepalive = pool_max_keepalive
+        self._pool_recycle_seconds = pool_recycle_seconds
         
         # Configure connection pool limits for better performance
-        limits = httpx.Limits(
-            max_connections=pool_max_connections,
-            max_keepalive_connections=pool_max_keepalive,
-        )
+        limits_kwargs: dict[str, Any] = {
+            "max_connections": pool_max_connections,
+            "max_keepalive_connections": pool_max_keepalive,
+        }
+        if pool_recycle_seconds is not None:
+            limits_kwargs["keepalive_expiry"] = pool_recycle_seconds
+        limits = httpx.Limits(**limits_kwargs)
         self._http = httpx.Client(timeout=timeout, limits=limits)
+
+    def pool_health(self) -> PoolHealth:
+        """Inspect the current httpx pool stats (best-effort)."""
+        transport = getattr(self._http, "_transport", None)
+        pool = getattr(transport, "_pool", None) if transport is not None else None
+        active = 0
+        idle = 0
+        if pool is not None:
+            connections = list(getattr(pool, "_connections", []))
+            for conn in connections:
+                try:
+                    is_closed = getattr(conn, "is_closed")
+                except AttributeError:
+                    is_closed = None
+                if callable(is_closed):
+                    try:
+                        if is_closed():
+                            continue
+                    except Exception:
+                        pass
+                try:
+                    is_idle = getattr(conn, "is_idle")
+                except AttributeError:
+                    is_idle = None
+                if callable(is_idle):
+                    try:
+                        if is_idle():
+                            idle += 1
+                            continue
+                    except Exception:
+                        pass
+                active += 1
+            max_connections = getattr(pool, "_max_connections", self._pool_max_connections)
+            max_keepalive = getattr(pool, "_max_keepalive_connections", self._pool_max_keepalive)
+        else:
+            max_connections = self._pool_max_connections
+            max_keepalive = self._pool_max_keepalive
+        return {
+            "active_connections": active,
+            "idle_connections": idle,
+            "max_connections": max_connections,
+            "max_keepalive_connections": max_keepalive,
+            "recycle_seconds": self._pool_recycle_seconds,
+        }
+
+    def warm_up(self, *, path: str = "/v1/free-tier/info", timeout: float | None = None) -> None:
+        """Open a connection eagerly so latency spikes don't hit the first user request."""
+        effective_timeout = timeout if timeout is not None else min(self._timeout, 5.0)
+        try:
+            self.request("GET", path, timeout=effective_timeout)
+        except Exception as exc:
+            raise ConnectionError("MemoClaw connection pool warm-up failed") from exc
 
     def request(
         self,
@@ -312,6 +382,7 @@ class _AsyncHTTPClient:
         max_retries: int = DEFAULT_MAX_RETRIES,
         pool_max_connections: int = DEFAULT_POOL_MAX_CONNECTIONS,
         pool_max_keepalive: int = DEFAULT_POOL_MAX_KEEPALIVE_CONNECTIONS,
+        pool_recycle_seconds: float | None = None,
         wallet_address: str | None = None,
     ) -> None:
         if private_key is not None:
@@ -328,13 +399,71 @@ class _AsyncHTTPClient:
         self._timeout = timeout
         self._max_retries = max_retries
         self._user_agent = _sdk_user_agent()
+        self._pool_max_connections = pool_max_connections
+        self._pool_max_keepalive = pool_max_keepalive
+        self._pool_recycle_seconds = pool_recycle_seconds
         
         # Configure connection pool limits for better performance
-        limits = httpx.Limits(
-            max_connections=pool_max_connections,
-            max_keepalive_connections=pool_max_keepalive,
-        )
+        limits_kwargs: dict[str, Any] = {
+            "max_connections": pool_max_connections,
+            "max_keepalive_connections": pool_max_keepalive,
+        }
+        if pool_recycle_seconds is not None:
+            limits_kwargs["keepalive_expiry"] = pool_recycle_seconds
+        limits = httpx.Limits(**limits_kwargs)
         self._http = httpx.AsyncClient(timeout=timeout, limits=limits)
+
+    def pool_health(self) -> PoolHealth:
+        """Inspect async httpx pool stats without awaiting."""
+        transport = getattr(self._http, "_transport", None)
+        pool = getattr(transport, "_pool", None) if transport is not None else None
+        active = 0
+        idle = 0
+        if pool is not None:
+            connections = list(getattr(pool, "_connections", []))
+            for conn in connections:
+                try:
+                    is_closed = getattr(conn, "is_closed")
+                except AttributeError:
+                    is_closed = None
+                if callable(is_closed):
+                    try:
+                        if is_closed():
+                            continue
+                    except Exception:
+                        pass
+                try:
+                    is_idle = getattr(conn, "is_idle")
+                except AttributeError:
+                    is_idle = None
+                if callable(is_idle):
+                    try:
+                        if is_idle():
+                            idle += 1
+                            continue
+                    except Exception:
+                        pass
+                active += 1
+            max_connections = getattr(pool, "_max_connections", self._pool_max_connections)
+            max_keepalive = getattr(pool, "_max_keepalive_connections", self._pool_max_keepalive)
+        else:
+            max_connections = self._pool_max_connections
+            max_keepalive = self._pool_max_keepalive
+        return {
+            "active_connections": active,
+            "idle_connections": idle,
+            "max_connections": max_connections,
+            "max_keepalive_connections": max_keepalive,
+            "recycle_seconds": self._pool_recycle_seconds,
+        }
+
+    async def warm_up(self, *, path: str = "/v1/free-tier/info", timeout: float | None = None) -> None:
+        """Async variant of the eager warm-up helper."""
+        effective_timeout = timeout if timeout is not None else min(self._timeout, 5.0)
+        try:
+            await self.request("GET", path, timeout=effective_timeout)
+        except Exception as exc:
+            raise ConnectionError("MemoClaw connection pool warm-up failed") from exc
 
     async def request(
         self,

--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -21,6 +21,7 @@ from ._client import (
     DEFAULT_TIMEOUT,
     LogFormat,
     LogLevel,
+    PoolHealth,
     _AsyncHTTPClient,
     _SyncHTTPClient,
     configure_sdk_logging,
@@ -217,6 +218,9 @@ class MemoClaw:
         max_retries: Maximum retry attempts for transient errors. Defaults to 2.
         pool_max_connections: Maximum number of connections in the pool. Defaults to 10.
         pool_max_keepalive: Maximum number of keep-alive connections. Defaults to 5.
+        pool_recycle_seconds: Seconds before idle sockets are discarded. Defaults to httpx's keepalive expiry.
+        pool_recycle_seconds: Seconds before idle sockets are discarded. Defaults to httpx's keepalive expiry.
+        warm_pool: If True, performs a lightweight warm-up request during initialization.
     """
 
     def __init__(
@@ -229,8 +233,10 @@ class MemoClaw:
         max_retries: int | None = None,
         pool_max_connections: int = DEFAULT_POOL_MAX_CONNECTIONS,
         pool_max_keepalive: int = DEFAULT_POOL_MAX_KEEPALIVE_CONNECTIONS,
+        pool_recycle_seconds: float | None = None,
         config_path: str | Path | None = None,
         validate_on_init: bool = False,
+        warm_pool: bool = False,
         log_level: LogLevel | None = None,
         log_format: LogFormat = "text",
     ) -> None:
@@ -262,6 +268,8 @@ class MemoClaw:
             kwargs["wallet_address"] = resolved_wallet
         if max_retries is not None:
             kwargs["max_retries"] = max_retries
+        if pool_recycle_seconds is not None:
+            kwargs["pool_recycle_seconds"] = pool_recycle_seconds
         self._http = _SyncHTTPClient(**kwargs)
         self._before_request_hooks: _list[BeforeRequestHook] = []
         self._after_response_hooks: _list[AfterResponseHook] = []
@@ -274,6 +282,13 @@ class MemoClaw:
                     f"MemoClaw health check failed (latency: {result.latency_ms:.0f}ms). "
                     "Check your network connection and base_url."
                 )
+
+        if warm_pool:
+            try:
+                self._http.warm_up()
+            except Exception:
+                self.close()
+                raise
 
     # ── Auth helpers ────────────────────────────────────────────────────
 
@@ -356,6 +371,14 @@ class MemoClaw:
 
     def __exit__(self, *args: Any) -> None:
         self.close()
+
+    def pool_health(self) -> PoolHealth:
+        """Return the current connection pool stats."""
+        return self._http.pool_health()
+
+    def warm_pool(self, *, timeout: float | None = None) -> None:
+        """Warm the pool on demand (same as setting warm_pool=True on init)."""
+        self._http.warm_up(timeout=timeout)
 
     # ── Store ────────────────────────────────────────────────────────────
 
@@ -1547,6 +1570,7 @@ class AsyncMemoClaw:
         max_retries: int | None = None,
         pool_max_connections: int = DEFAULT_POOL_MAX_CONNECTIONS,
         pool_max_keepalive: int = DEFAULT_POOL_MAX_KEEPALIVE_CONNECTIONS,
+        pool_recycle_seconds: float | None = None,
         config_path: str | Path | None = None,
         log_level: LogLevel | None = None,
         log_format: LogFormat = "text",
@@ -1579,6 +1603,8 @@ class AsyncMemoClaw:
             kwargs["wallet_address"] = resolved_wallet
         if max_retries is not None:
             kwargs["max_retries"] = max_retries
+        if pool_recycle_seconds is not None:
+            kwargs["pool_recycle_seconds"] = pool_recycle_seconds
         self._http = _AsyncHTTPClient(**kwargs)
         self._before_request_hooks: _list[BeforeRequestHook] = []
         self._after_response_hooks: _list[AfterResponseHook] = []
@@ -1597,10 +1623,12 @@ class AsyncMemoClaw:
         max_retries: int | None = None,
         pool_max_connections: int = DEFAULT_POOL_MAX_CONNECTIONS,
         pool_max_keepalive: int = DEFAULT_POOL_MAX_KEEPALIVE_CONNECTIONS,
+        pool_recycle_seconds: float | None = None,
         config_path: str | Path | None = None,
         log_level: LogLevel | None = None,
         log_format: LogFormat = "text",
         validate_on_init: bool = True,
+        warm_pool: bool = False,
     ) -> AsyncMemoClaw:
         """Async factory that creates and optionally validates the client.
 
@@ -1620,12 +1648,15 @@ class AsyncMemoClaw:
             max_retries=max_retries,
             pool_max_connections=pool_max_connections,
             pool_max_keepalive=pool_max_keepalive,
+            pool_recycle_seconds=pool_recycle_seconds,
             config_path=config_path,
             log_level=log_level,
             log_format=log_format,
         )
         if validate_on_init:
             await client.ping()
+        if warm_pool:
+            await client.warm_pool()
         return client
 
     # ── Auth helpers ────────────────────────────────────────────────────
@@ -1709,6 +1740,14 @@ class AsyncMemoClaw:
 
     async def __aexit__(self, *args: Any) -> None:
         await self.close()
+
+    def pool_health(self) -> PoolHealth:
+        """Return async connection pool stats (no await needed)."""
+        return self._http.pool_health()
+
+    async def warm_pool(self, *, timeout: float | None = None) -> None:
+        """Warm the async pool on demand."""
+        await self._http.warm_up(timeout=timeout)
 
     # ── Store ────────────────────────────────────────────────────────────
 

--- a/python/tests/test_connection_pool.py
+++ b/python/tests/test_connection_pool.py
@@ -39,6 +39,53 @@ class TestConnectionPool:
         assert isinstance(client._http._http, httpx.Client)
         client.close()
 
+    def test_pool_health_snapshot(self, monkeypatch):
+        """pool_health should surface idle/active/max counts."""
+        class FakeConn:
+            def __init__(self, idle: bool, closed: bool = False) -> None:
+                self._idle = idle
+                self._closed = closed
+
+            def is_idle(self) -> bool:
+                return self._idle
+
+            def is_closed(self) -> bool:
+                return self._closed
+
+        client = MemoClaw(private_key=TEST_PRIVATE_KEY, base_url=BASE_URL)
+        fake_pool = MagicMock()
+        fake_pool._connections = [FakeConn(True), FakeConn(False), FakeConn(False, closed=True)]
+        fake_pool._max_connections = 12
+        fake_pool._max_keepalive_connections = 6
+
+        class FakeTransport:
+            def __init__(self) -> None:
+                self._pool = fake_pool
+
+            def close(self) -> None:
+                pass
+
+        client._http._http._transport = FakeTransport()
+        health = client.pool_health()
+        assert health["idle_connections"] == 1
+        assert health["active_connections"] == 1
+        assert health["max_connections"] == 12
+        assert health["max_keepalive_connections"] == 6
+        client.close()
+
+    def test_warm_pool_option_triggers_helper(self, monkeypatch):
+        """warm_pool=True should call the underlying warm_up helper once."""
+        calls = {"count": 0}
+
+        def fake_warm_up(self, *, path="/v1/free-tier/info", timeout=None):  # type: ignore[override]
+            calls["count"] += 1
+
+        monkeypatch.setattr("memoclaw.client._SyncHTTPClient.warm_up", fake_warm_up, raising=False)
+        client = MemoClaw(private_key=TEST_PRIVATE_KEY, base_url=BASE_URL, warm_pool=True)
+        assert calls["count"] == 1
+        client.close()
+
+
 
 class TestAsyncConnectionPool:
     """Test async client connection pool configuration."""
@@ -68,6 +115,24 @@ class TestAsyncConnectionPool:
         assert client._http._http is not None
         assert isinstance(client._http._http, httpx.AsyncClient)
         await client.close()
+    @pytest.mark.asyncio
+    async def test_async_create_warm_pool_option(self, monkeypatch):
+        """Async factory should warm the pool when requested."""
+        calls = {"count": 0}
+
+        async def fake_warm_up(self, *, path="/v1/free-tier/info", timeout=None):  # type: ignore[override]
+            calls["count"] += 1
+
+        monkeypatch.setattr("memoclaw.client._AsyncHTTPClient.warm_up", fake_warm_up, raising=False)
+        client = await AsyncMemoClaw.create(
+            private_key=TEST_PRIVATE_KEY,
+            base_url=BASE_URL,
+            validate_on_init=False,
+            warm_pool=True,
+        )
+        assert calls["count"] == 1
+        await client.close()
+
 
 
 class TestRetryConfiguration:


### PR DESCRIPTION
## Summary
- add pool_health() + warm_pool controls to MemoClaw/AsyncMemoClaw
- expose pool_recycle_seconds knob + connection warm-up helper in HTTP clients
- document the new knobs and add regression tests

## Testing
- pytest tests/test_connection_pool.py

Fixes #215