### PR TITLE
feat: add memory lifecycle callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Warm-up toggle** — new `warm_pool` flag (sync constructor + async factory) plus `warm_pool()` helpers to pre-establish TCP/TLS connections (#215)
 - **Connection recycling control** — `pool_recycle_seconds` forwards to httpx keepalive expiry so stale sockets are churned proactively (#215)
 - **Docs/tests** — README describes the new knobs and regression tests guard warm-up + health reporting behaviors (#215)
+- Add memory lifecycle callbacks (on_store/on_recall/on_delete) to Python + TypeScript SDKs (#214)
+
+### Documentation
+- Document lifecycle callback usage in both SDK READMEs (#214)
 
 ## [1.0.0] - 2026-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Docs/tests** — README describes the new knobs and regression tests guard warm-up + health reporting behaviors (#215)
 - Add memory lifecycle callbacks (on_store/on_recall/on_delete) to Python + TypeScript SDKs (#214)
 
+### Fixes
+- Export the onError lifecycle hook for the TypeScript SDK and ensure hooks are awaited before throwing (#214)
+
 ### Documentation
 - Document lifecycle callback usage in both SDK READMEs (#214)
 

--- a/python/README.md
+++ b/python/README.md
@@ -73,6 +73,22 @@ async def main():
         memories = await client.recall("async")
 ```
 
+## Lifecycle Callbacks
+
+Both clients support high-level memory lifecycle callbacks that fire after specific operations.
+Use these to tag memories, send analytics, or trigger side effects without reimplementing SDK logic.
+
+```python
+from memoclaw import MemoClaw
+
+client = MemoClaw(private_key="0x...")
+client.on_store(lambda result: print(f"Stored {result.id}"))
+client.on_recall(lambda query, resp: print(f"recall {query} -> {len(resp.memories)} results"))
+client.on_delete(lambda memory_id, _: print(f"Deleted {memory_id}"))
+```
+
+`AsyncMemoClaw` supports `async def` callbacks — awaited automatically after each operation.
+
 ## All Methods
 
 | Method | Description |

--- a/python/src/memoclaw/client.py
+++ b/python/src/memoclaw/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 from types import EllipsisType
 from urllib.parse import quote
@@ -200,6 +201,9 @@ def _build_store_body(
 BeforeRequestHook = Callable[[str, str, dict[str, Any] | None], dict[str, Any] | None]
 AfterResponseHook = Callable[[str, str, Any], Any]
 OnErrorHook = Callable[[str, str, Exception], None]
+StoreCallback = Callable[[StoreResult | StoreBatchResult], Any]
+RecallCallback = Callable[[str, RecallResponse], Any]
+DeleteCallback = Callable[[str, DeleteResult | DeleteBatchItemResult], Any]
 
 
 class MemoClaw:
@@ -274,6 +278,9 @@ class MemoClaw:
         self._before_request_hooks: _list[BeforeRequestHook] = []
         self._after_response_hooks: _list[AfterResponseHook] = []
         self._on_error_hooks: _list[OnErrorHook] = []
+        self._store_callbacks: _list[StoreCallback] = []
+        self._recall_callbacks: _list[RecallCallback] = []
+        self._delete_callbacks: _list[DeleteCallback] = []
 
         if validate_on_init:
             result = self.ping()
@@ -321,6 +328,48 @@ class MemoClaw:
         """Register a hook called on errors. Returns self for chaining."""
         self._on_error_hooks.append(hook)
         return self
+
+    def on_store(self, callback: StoreCallback) -> MemoClaw:
+        """Register a callback fired after successful store/store_batch calls."""
+        self._store_callbacks.append(callback)
+        return self
+
+    def on_recall(self, callback: RecallCallback) -> MemoClaw:
+        """Register a callback fired after successful recall/search calls."""
+        self._recall_callbacks.append(callback)
+        return self
+
+    def on_delete(self, callback: DeleteCallback) -> MemoClaw:
+        """Register a callback fired after delete/delete_batch calls."""
+        self._delete_callbacks.append(callback)
+        return self
+
+    def _emit_store_callbacks(self, payload: StoreResult | StoreBatchResult) -> None:
+        for callback in self._store_callbacks:
+            maybe = callback(payload)
+            if inspect.isawaitable(maybe):
+                raise RuntimeError(
+                    "MemoClaw.on_store callbacks must be synchronous. "
+                    "Use AsyncMemoClaw for awaitable lifecycle handlers."
+                )
+
+    def _emit_recall_callbacks(self, query: str, payload: RecallResponse) -> None:
+        for callback in self._recall_callbacks:
+            maybe = callback(query, payload)
+            if inspect.isawaitable(maybe):
+                raise RuntimeError(
+                    "MemoClaw.on_recall callbacks must be synchronous. "
+                    "Use AsyncMemoClaw for awaitable lifecycle handlers."
+                )
+
+    def _emit_delete_callbacks(self, memory_id: str, payload: DeleteResult | DeleteBatchItemResult) -> None:
+        for callback in self._delete_callbacks:
+            maybe = callback(memory_id, payload)
+            if inspect.isawaitable(maybe):
+                raise RuntimeError(
+                    "MemoClaw.on_delete callbacks must be synchronous. "
+                    "Use AsyncMemoClaw for awaitable lifecycle handlers."
+                )
 
     def _run_request(
         self,
@@ -421,7 +470,9 @@ class MemoClaw:
             metadata=metadata,
         )
         data = self._run_request("POST", "/v1/store", json=body, timeout=timeout)
-        return StoreResult.model_validate(data)
+        result = StoreResult.model_validate(data)
+        self._emit_store_callbacks(result)
+        return result
 
     def store_batch(
         self,
@@ -462,7 +513,9 @@ class MemoClaw:
             for m in memories
         ]
         data = self._run_request("POST", "/v1/store/batch", json={"memories": items}, timeout=timeout)
-        return StoreBatchResult.model_validate(data)
+        result = StoreBatchResult.model_validate(data)
+        self._emit_store_callbacks(result)
+        return result
 
     def store_builder(self) -> StoreBuilder:
         """Create a StoreBuilder for fluent memory creation.
@@ -522,7 +575,9 @@ class MemoClaw:
             body["filters"] = filters
 
         data = self._run_request("POST", "/v1/recall", json=body, timeout=timeout)
-        return RecallResponse.model_validate(data)
+        result = RecallResponse.model_validate(data)
+        self._emit_recall_callbacks(query, result)
+        return result
 
     # ── List ─────────────────────────────────────────────────────────────
 
@@ -761,7 +816,9 @@ class MemoClaw:
         """Delete a memory by ID."""
         _validate_non_empty(memory_id, "memory_id")
         data = self._run_request("DELETE", f"/v1/memories/{quote(memory_id, safe='')}", timeout=timeout)
-        return DeleteResult.model_validate(data)
+        result = DeleteResult.model_validate(data)
+        self._emit_delete_callbacks(memory_id, result)
+        return result
 
     def delete_batch(self, memory_ids: _list[str], *, timeout: float | None = None) -> _list[DeleteBatchItemResult]:
         """Delete multiple memories by ID using the batch endpoint.
@@ -778,7 +835,9 @@ class MemoClaw:
                 "POST", "/v1/memories/batch-delete", json={"ids": chunk}, timeout=timeout
             )
             for item in data.get("results", []):
-                results.append(DeleteBatchItemResult.model_validate(item))
+                parsed = DeleteBatchItemResult.model_validate(item)
+                results.append(parsed)
+                self._emit_delete_callbacks(parsed.id, parsed)
         return results
 
     #: Alias for :meth:`recall` — matches Mem0/Pinecone ``search`` convention.
@@ -1613,6 +1672,9 @@ class AsyncMemoClaw:
         self._before_request_hooks: _list[BeforeRequestHook] = []
         self._after_response_hooks: _list[AfterResponseHook] = []
         self._on_error_hooks: _list[OnErrorHook] = []
+        self._store_callbacks: _list[StoreCallback] = []
+        self._recall_callbacks: _list[RecallCallback] = []
+        self._delete_callbacks: _list[DeleteCallback] = []
 
     # ── Factory ──────────────────────────────────────────────────────────
 
@@ -1694,6 +1756,39 @@ class AsyncMemoClaw:
         """Register a hook called on errors. Returns self for chaining."""
         self._on_error_hooks.append(hook)
         return self
+
+    def on_store(self, callback: StoreCallback) -> AsyncMemoClaw:
+        """Register a callback fired after successful store/store_batch calls."""
+        self._store_callbacks.append(callback)
+        return self
+
+    def on_recall(self, callback: RecallCallback) -> AsyncMemoClaw:
+        """Register a callback fired after successful recall/search calls."""
+        self._recall_callbacks.append(callback)
+        return self
+
+    def on_delete(self, callback: DeleteCallback) -> AsyncMemoClaw:
+        """Register a callback fired after delete/delete_batch calls."""
+        self._delete_callbacks.append(callback)
+        return self
+
+    async def _emit_store_callbacks(self, payload: StoreResult | StoreBatchResult) -> None:
+        for callback in self._store_callbacks:
+            maybe = callback(payload)
+            if inspect.isawaitable(maybe):
+                await maybe
+
+    async def _emit_recall_callbacks(self, query: str, payload: RecallResponse) -> None:
+        for callback in self._recall_callbacks:
+            maybe = callback(query, payload)
+            if inspect.isawaitable(maybe):
+                await maybe
+
+    async def _emit_delete_callbacks(self, memory_id: str, payload: DeleteResult | DeleteBatchItemResult) -> None:
+        for callback in self._delete_callbacks:
+            maybe = callback(memory_id, payload)
+            if inspect.isawaitable(maybe):
+                await maybe
 
     async def _run_request(
         self,
@@ -1794,7 +1889,9 @@ class AsyncMemoClaw:
             metadata=metadata,
         )
         data = await self._run_request("POST", "/v1/store", json=body, timeout=timeout)
-        return StoreResult.model_validate(data)
+        result = StoreResult.model_validate(data)
+        await self._emit_store_callbacks(result)
+        return result
 
     async def store_batch(
         self,
@@ -1837,7 +1934,9 @@ class AsyncMemoClaw:
         data = await self._run_request(
             "POST", "/v1/store/batch", json={"memories": items}, timeout=timeout
         )
-        return StoreBatchResult.model_validate(data)
+        result = StoreBatchResult.model_validate(data)
+        await self._emit_store_callbacks(result)
+        return result
 
     def store_builder(self) -> AsyncStoreBuilder:
         """Create an AsyncStoreBuilder for fluent memory creation.
@@ -1897,7 +1996,9 @@ class AsyncMemoClaw:
             body["filters"] = filters
 
         data = await self._run_request("POST", "/v1/recall", json=body, timeout=timeout)
-        return RecallResponse.model_validate(data)
+        result = RecallResponse.model_validate(data)
+        await self._emit_recall_callbacks(query, result)
+        return result
 
     # ── List ─────────────────────────────────────────────────────────────
 
@@ -2138,7 +2239,9 @@ class AsyncMemoClaw:
         """Delete a memory by ID."""
         _validate_non_empty(memory_id, "memory_id")
         data = await self._run_request("DELETE", f"/v1/memories/{quote(memory_id, safe='')}", timeout=timeout)
-        return DeleteResult.model_validate(data)
+        result = DeleteResult.model_validate(data)
+        await self._emit_delete_callbacks(memory_id, result)
+        return result
 
     async def delete_batch(self, memory_ids: _list[str], *, timeout: float | None = None) -> _list[DeleteBatchItemResult]:
         """Delete multiple memories by ID using the batch endpoint.
@@ -2155,7 +2258,9 @@ class AsyncMemoClaw:
                 "POST", "/v1/memories/batch-delete", json={"ids": chunk}, timeout=timeout
             )
             for item in data.get("results", []):
-                results.append(DeleteBatchItemResult.model_validate(item))
+                parsed = DeleteBatchItemResult.model_validate(item)
+                results.append(parsed)
+                await self._emit_delete_callbacks(parsed.id, parsed)
         return results
 
     #: Alias for :meth:`recall` — matches Mem0/Pinecone ``search`` convention.

--- a/python/tests/test_lifecycle_callbacks.py
+++ b/python/tests/test_lifecycle_callbacks.py
@@ -1,0 +1,155 @@
+"""Tests for memory lifecycle callbacks."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from memoclaw import MemoClaw, AsyncMemoClaw
+
+TEST_PRIVATE_KEY = "0x4c0883a69102937d6231471b5dbb6204fe512961708279f15a8f7e20b4e3b1fb"
+BASE_URL = "https://api.memoclaw.com"
+
+
+@pytest.fixture
+def client() -> MemoClaw:
+    c = MemoClaw(private_key=TEST_PRIVATE_KEY, base_url=BASE_URL)
+    yield c
+    c.close()
+
+
+@pytest.fixture
+async def async_client() -> AsyncMemoClaw:
+    c = AsyncMemoClaw(private_key=TEST_PRIVATE_KEY, base_url=BASE_URL)
+    try:
+        yield c
+    finally:
+        await c.close()
+
+
+class TestSyncLifecycleCallbacks:
+    @respx.mock
+    def test_on_store_receives_store_result(self, client: MemoClaw) -> None:
+        events: list[str] = []
+        client.on_store(lambda result: events.append(result.id))
+
+        respx.post(f"{BASE_URL}/v1/store").mock(
+            return_value=httpx.Response(
+                201,
+                json={"id": "mem-1", "stored": True, "deduplicated": False, "tokens_used": 4},
+            )
+        )
+
+        client.store("testing callbacks")
+
+        assert events == ["mem-1"]
+
+    @respx.mock
+    def test_on_recall_receives_query_and_results(self, client: MemoClaw) -> None:
+        captured: list[tuple[str, int]] = []
+        client.on_recall(lambda query, result: captured.append((query, len(result.memories))))
+
+        respx.post(f"{BASE_URL}/v1/recall").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "memories": [
+                        {
+                            "id": "mem-1",
+                            "content": "hello",
+                            "similarity": 0.9,
+                            "metadata": {},
+                            "importance": 0.5,
+                            "memory_type": "general",
+                            "namespace": "default",
+                            "session_id": None,
+                            "agent_id": None,
+                            "created_at": "2025-01-01",
+                            "access_count": 1,
+                            "pinned": False,
+                            "immutable": False,
+                        }
+                    ],
+                    "query_tokens": 12,
+                },
+            )
+        )
+
+        client.recall("dark mode prefs")
+
+        assert captured == [("dark mode prefs", 1)]
+
+    @respx.mock
+    def test_on_delete_invoked_for_single_and_batch(self, client: MemoClaw) -> None:
+        events: list[str] = []
+        client.on_delete(lambda memory_id, _: events.append(memory_id))
+
+        respx.delete(f"{BASE_URL}/v1/memories/mem-1").mock(
+            return_value=httpx.Response(200, json={"deleted": True, "id": "mem-1"})
+        )
+        respx.post(f"{BASE_URL}/v1/memories/batch-delete").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {"id": "mem-2", "deleted": True},
+                        {"id": "mem-3", "deleted": False, "error": "not found"},
+                    ]
+                },
+            )
+        )
+
+        client.delete("mem-1")
+        client.delete_batch(["mem-2", "mem-3"])
+
+        assert events == ["mem-1", "mem-2", "mem-3"]
+
+
+class TestAsyncLifecycleCallbacks:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_store_callback_can_await(self, async_client: AsyncMemoClaw) -> None:
+        events: list[str] = []
+
+        async def track(result):
+            events.append(result.id)
+
+        async_client.on_store(track)
+
+        respx.post(f"{BASE_URL}/v1/store").mock(
+            return_value=httpx.Response(
+                201,
+                json={"id": "mem-async", "stored": True, "deduplicated": False, "tokens_used": 5},
+            )
+        )
+
+        await async_client.store("async store")
+
+        assert events == ["mem-async"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_delete_batch_triggers_callbacks(self, async_client: AsyncMemoClaw) -> None:
+        seen: list[str] = []
+
+        async def track(memory_id, _):
+            seen.append(memory_id)
+
+        async_client.on_delete(track)
+
+        respx.post(f"{BASE_URL}/v1/memories/batch-delete").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {"id": "mem-a", "deleted": True},
+                        {"id": "mem-b", "deleted": True},
+                    ]
+                },
+            )
+        )
+
+        await async_client.delete_batch(["mem-a", "mem-b"])
+
+        assert seen == ["mem-a", "mem-b"]

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -54,6 +54,19 @@ const ingested = await client.ingest({
 const suggestions = await client.suggested({ category: 'stale' });
 ```
 
+## Lifecycle Callbacks
+
+High-level lifecycle hooks sit above the raw before/after request middleware:
+
+```ts
+const client = new MemoClawClient({ privateKey: process.env.MEMOCLAW_PRIVATE_KEY! });
+client.onStore((result) => console.log(`stored ${result.id}`));
+client.onRecall((query, response) => console.log(`recall ${query} -> ${response.memories.length} hits`));
+client.onDelete((id, outcome) => console.log(`delete ${id}: ${outcome.deleted}`));
+```
+
+Callbacks run after successful operations, and you can register multiple handlers per event.
+
 ## Authentication
 
 MemoClaw uses Ethereum wallet signatures for authentication. You need a private key (any Ethereum key works — no ETH balance needed for the free tier).

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -63,6 +63,7 @@ const client = new MemoClawClient({ privateKey: process.env.MEMOCLAW_PRIVATE_KEY
 client.onStore((result) => console.log(`stored ${result.id}`));
 client.onRecall((query, response) => console.log(`recall ${query} -> ${response.memories.length} hits`));
 client.onDelete((id, outcome) => console.log(`delete ${id}: ${outcome.deleted}`));
+client.onError((method, path, err) => console.error(`failed ${method} ${path}`, err));
 ```
 
 Callbacks run after successful operations, and you can register multiple handlers per event.

--- a/typescript/src/__tests__/lifecycle-hooks.test.ts
+++ b/typescript/src/__tests__/lifecycle-hooks.test.ts
@@ -14,7 +14,7 @@ function mockFetch(responses: Array<{ status: number; body?: unknown; ok?: boole
       status: resp.status,
       json: async () => resp.body,
       headers: { get: () => null },
-    } as Response;
+    } as unknown as Response;
   });
 }
 

--- a/typescript/src/__tests__/lifecycle-hooks.test.ts
+++ b/typescript/src/__tests__/lifecycle-hooks.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MemoClawClient } from '../index.js';
+
+const BASE_URL = 'https://api.memoclaw.com';
+const TEST_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+function mockFetch(responses: Array<{ status: number; body?: unknown; ok?: boolean }>): typeof globalThis.fetch {
+  let callIndex = 0;
+  return vi.fn(async () => {
+    const resp = responses[callIndex] ?? responses[responses.length - 1]!;
+    callIndex += 1;
+    return {
+      ok: resp.ok ?? (resp.status >= 200 && resp.status < 300),
+      status: resp.status,
+      json: async () => resp.body,
+      headers: { get: () => null },
+    } as Response;
+  });
+}
+
+function createClient(fetchImpl: typeof globalThis.fetch): MemoClawClient {
+  return new MemoClawClient({
+    privateKey: TEST_PRIVATE_KEY,
+    baseUrl: BASE_URL,
+    fetch: fetchImpl,
+  });
+}
+
+describe('lifecycle callbacks', () => {
+  it('invokes onStore callbacks for store and storeBatch', async () => {
+    const fetchImpl = mockFetch([
+      { status: 201, body: { id: 'mem-1', stored: true, deduplicated: false, tokens_used: 10 } },
+      { status: 201, body: { ids: ['mem-2'], stored: true, count: 1, deduplicated_count: 0, tokens_used: 20 } },
+    ]);
+    const client = createClient(fetchImpl);
+    const handler = vi.fn();
+    client.onStore(handler);
+
+    await client.store({ content: 'first' });
+    await client.storeBatch([{ content: 'second' }]);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenNthCalledWith(1, expect.objectContaining({ id: 'mem-1' }));
+    expect(handler).toHaveBeenNthCalledWith(2, expect.objectContaining({ ids: ['mem-2'] }));
+  });
+
+  it('invokes onRecall callbacks with query and response payload', async () => {
+    const fetchImpl = mockFetch([
+      {
+        status: 200,
+        body: {
+          memories: [
+            {
+              id: 'mem-1',
+              content: 'note',
+              similarity: 0.9,
+              metadata: {},
+              importance: 0.5,
+              memory_type: 'general',
+              namespace: 'default',
+              session_id: null,
+              agent_id: null,
+              created_at: '2025-01-01',
+              access_count: 0,
+              pinned: false,
+              immutable: false,
+            },
+          ],
+          query_tokens: 12,
+        },
+      },
+    ]);
+    const client = createClient(fetchImpl);
+    const handler = vi.fn();
+    client.onRecall(handler);
+
+    await client.recall({ query: 'roadmap' });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith('roadmap', expect.objectContaining({ memories: expect.any(Array) }));
+  });
+
+  it('invokes onDelete callbacks for single and batch deletes', async () => {
+    const fetchImpl = mockFetch([
+      { status: 200, body: { deleted: true, id: 'mem-1' } },
+      {
+        status: 200,
+        body: {
+          results: [
+            { id: 'mem-2', deleted: true },
+            { id: 'mem-3', deleted: false, error: 'not found' },
+          ],
+        },
+      },
+    ]);
+    const client = createClient(fetchImpl);
+    const handler = vi.fn();
+    client.onDelete(handler);
+
+    await client.delete('mem-1');
+    await client.deleteBatch(['mem-2', 'mem-3']);
+
+    expect(handler).toHaveBeenCalledTimes(3);
+    expect(handler).toHaveBeenNthCalledWith(1, 'mem-1', expect.objectContaining({ deleted: true }));
+    expect(handler).toHaveBeenNthCalledWith(2, 'mem-2', expect.objectContaining({ deleted: true }));
+    expect(handler).toHaveBeenNthCalledWith(3, 'mem-3', expect.objectContaining({ error: 'not found' }));
+  });
+});

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -13,6 +13,7 @@ import type {
   ListMemoriesParams,
   UpdateMemoryRequest,
   DeleteResponse,
+  DeleteBatchResult,
   IngestRequest,
   IngestResponse,
   SuggestedParams,
@@ -185,7 +186,9 @@ export type BeforeRequestHook = (method: string, path: string, body?: unknown) =
 /** Hook called after each successful response. */
 export type AfterResponseHook = (method: string, path: string, data: unknown) => unknown | void;
 /** Hook called on error. */
-export type OnErrorHook = (method: string, path: string, error: MemoClawError) => void;
+export type StoreCallback = (result: StoreResponse | StoreBatchResponse) => void | Promise<void>;
+export type RecallCallback = (query: string, response: RecallResponse) => void | Promise<void>;
+export type DeleteCallback = (id: string, result: DeleteResponse | DeleteBatchResult) => void | Promise<void>;
 
 /**
  * Official TypeScript client for the MemoClaw memory API.
@@ -211,6 +214,9 @@ export class MemoClawClient {
   private readonly _beforeRequestHooks: BeforeRequestHook[] = [];
   private readonly _afterResponseHooks: AfterResponseHook[] = [];
   private readonly _onErrorHooks: OnErrorHook[] = [];
+  private readonly _storeCallbacks: StoreCallback[] = [];
+  private readonly _recallCallbacks: RecallCallback[] = [];
+  private readonly _deleteCallbacks: DeleteCallback[] = [];
   private readonly _logger?: Required<Logger>;
 
   constructor(options: MemoClawOptions = {}) {
@@ -283,10 +289,40 @@ export class MemoClawClient {
     return this;
   }
 
-  /** Register a hook called on errors. Returns this for chaining. */
-  onError(hook: OnErrorHook): this {
-    this._onErrorHooks.push(hook);
+  /** Register a lifecycle callback fired after successful store/storeBatch calls. */
+  onStore(callback: StoreCallback): this {
+    this._storeCallbacks.push(callback);
     return this;
+  }
+
+  /** Register a lifecycle callback fired after successful recall/search calls. */
+  onRecall(callback: RecallCallback): this {
+    this._recallCallbacks.push(callback);
+    return this;
+  }
+
+  /** Register a lifecycle callback fired after delete/deleteBatch calls. */
+  onDelete(callback: DeleteCallback): this {
+    this._deleteCallbacks.push(callback);
+    return this;
+  }
+
+  private async emitStoreCallbacks(payload: StoreResponse | StoreBatchResponse): Promise<void> {
+    for (const cb of this._storeCallbacks) {
+      await cb(payload);
+    }
+  }
+
+  private async emitRecallCallbacks(query: string, payload: RecallResponse): Promise<void> {
+    for (const cb of this._recallCallbacks) {
+      await cb(query, payload);
+    }
+  }
+
+  private async emitDeleteCallbacks(id: string, payload: DeleteResponse | DeleteBatchResult): Promise<void> {
+    for (const cb of this._deleteCallbacks) {
+      await cb(id, payload);
+    }
   }
 
   // ── Representation ──────────────────────────────────
@@ -528,7 +564,9 @@ export class MemoClawClient {
     if (request.importance !== undefined && (request.importance < 0 || request.importance > 1)) {
       throw new Error('importance must be between 0.0 and 1.0');
     }
-    return this.request<StoreResponse>('POST', '/v1/store', request, undefined, options);
+    const result = await this.request<StoreResponse>('POST', '/v1/store', request, undefined, options);
+    await this.emitStoreCallbacks(result);
+    return result;
   }
 
   /** Store multiple memories in a single request (up to 100). */
@@ -551,11 +589,13 @@ export class MemoClawClient {
         throw new Error('importance must be between 0.0 and 1.0');
       }
     }
-    return this.request<StoreBatchResponse>(
+    const result = await this.request<StoreBatchResponse>(
       'POST', '/v1/store/batch',
       { memories } satisfies StoreBatchRequest,
       undefined, options,
     );
+    await this.emitStoreCallbacks(result);
+    return result;
   }
 
   /** Create a StoreBuilder for fluent memory creation. */
@@ -578,6 +618,7 @@ export class MemoClawClient {
         mem.signals = mem._signals;
       }
     }
+    await this.emitRecallCallbacks(request.query, data);
     return data;
   }
 
@@ -704,25 +745,30 @@ export class MemoClawClient {
   /** Delete a memory by ID (soft delete). */
   async delete(id: string, options?: RequestOptions): Promise<DeleteResponse> {
     if (!id?.trim()) throw new Error('id must be a non-empty string');
-    return this.request<DeleteResponse>('DELETE', `/v1/memories/${encodeURIComponent(id)}`, undefined, undefined, options);
+    const result = await this.request<DeleteResponse>('DELETE', `/v1/memories/${encodeURIComponent(id)}`, undefined, undefined, options);
+    await this.emitDeleteCallbacks(id, result);
+    return result;
   }
 
   /** Delete multiple memories by ID in batch. */
-  async deleteBatch(ids: string[], options?: RequestOptions): Promise<import('./types.js').DeleteBatchResult[]> {
+  async deleteBatch(ids: string[], options?: RequestOptions): Promise<DeleteBatchResult[]> {
     if (!ids.length) {
       throw new Error('ids array must not be empty');
     }
-    const results: import('./types.js').DeleteBatchResult[] = [];
+    const results: DeleteBatchResult[] = [];
     // Process in chunks of 50
     for (let i = 0; i < ids.length; i += 50) {
       const chunk = ids.slice(i, i + 50);
-      const response = await this.request<{ results: import('./types.js').DeleteBatchResult[] }>(
+      const response = await this.request<{ results: DeleteBatchResult[] }>(
         'POST',
         '/v1/memories/batch-delete',
         { ids: chunk },
         undefined, options,
-    );
-      results.push(...response.results);
+      );
+      for (const entry of response.results) {
+        results.push(entry);
+        await this.emitDeleteCallbacks(entry.id, entry);
+      }
     }
     return results;
   }

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -186,6 +186,7 @@ export type BeforeRequestHook = (method: string, path: string, body?: unknown) =
 /** Hook called after each successful response. */
 export type AfterResponseHook = (method: string, path: string, data: unknown) => unknown | void;
 /** Hook called on error. */
+export type OnErrorHook = (method: string, path: string, error: MemoClawError) => void | Promise<void>;
 export type StoreCallback = (result: StoreResponse | StoreBatchResponse) => void | Promise<void>;
 export type RecallCallback = (query: string, response: RecallResponse) => void | Promise<void>;
 export type DeleteCallback = (id: string, result: DeleteResponse | DeleteBatchResult) => void | Promise<void>;
@@ -289,6 +290,12 @@ export class MemoClawClient {
     return this;
   }
 
+  /** Register a hook fired when a request ultimately fails. */
+  onError(hook: OnErrorHook): this {
+    this._onErrorHooks.push(hook);
+    return this;
+  }
+
   /** Register a lifecycle callback fired after successful store/storeBatch calls. */
   onStore(callback: StoreCallback): this {
     this._storeCallbacks.push(callback);
@@ -322,6 +329,12 @@ export class MemoClawClient {
   private async emitDeleteCallbacks(id: string, payload: DeleteResponse | DeleteBatchResult): Promise<void> {
     for (const cb of this._deleteCallbacks) {
       await cb(id, payload);
+    }
+  }
+
+  private async emitErrorHooks(method: string, path: string, error: MemoClawError): Promise<void> {
+    for (const hook of this._onErrorHooks) {
+      await hook(method, path, error);
     }
   }
 
@@ -537,7 +550,7 @@ export class MemoClawClient {
       });
 
       if (!RETRYABLE_STATUS_CODES.has(res.status)) {
-        for (const hook of this._onErrorHooks) hook(method, path, lastError);
+        await this.emitErrorHooks(method, path, lastError);
         throw lastError;
       }
 
@@ -545,7 +558,7 @@ export class MemoClawClient {
     }
 
     if (lastError) {
-      for (const hook of this._onErrorHooks) hook(method, path, lastError);
+      await this.emitErrorHooks(method, path, lastError);
     }
     throw lastError!;
   }


### PR DESCRIPTION
## Summary\n- add on_store/on_recall/on_delete lifecycle registries to Python + Async clients\n- add matching callbacks to the TypeScript SDK with request helpers\n- document the hooks and add coverage for both SDKs\n\nFixes #214\n\n## Testing\n- python/.venv/bin/pytest tests/test_lifecycle_callbacks.py\n- bun test lifecycle-hooks\n