### PR TITLE
feat(python): add pydantic ai integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Documentation
 - Document lifecycle callback usage in both SDK READMEs (#214)
 
+### Added
+- Pydantic AI integration with MemoClaw store/recall tools plus optional dependency extras (#213)
+
 ## [1.0.0] - 2026-03-11
 
 ### Breaking Changes

--- a/python/README.md
+++ b/python/README.md
@@ -14,7 +14,8 @@ With optional extras:
 pip install "memoclaw[x402]"            # automatic x402 payments
 pip install "memoclaw[langchain]"       # LangChain integration
 pip install "memoclaw[llamaindex]"      # LlamaIndex integration
-pip install "memoclaw[x402,langchain,llamaindex]"  # all extras
+pip install "memoclaw[pydantic-ai]"      # Pydantic AI integration
+pip install "memoclaw[x402,langchain,llamaindex,pydantic-ai]"  # all extras
 ```
 
 ## Quickstart
@@ -88,6 +89,35 @@ client.on_delete(lambda memory_id, _: print(f"Deleted {memory_id}"))
 ```
 
 `AsyncMemoClaw` supports `async def` callbacks — awaited automatically after each operation.
+
+## Pydantic AI Integration
+
+Install the extra dependencies and register MemoClaw tools directly on a Pydantic AI agent.
+
+```python
+from pydantic_ai import Agent
+from memoclaw import MemoClaw
+from memoclaw.integrations.pydantic_ai import (
+    MemoClawDeps,
+    memoclaw_store_tool,
+    memoclaw_recall_tool,
+)
+
+agent = Agent(
+    "gpt-4o-mini",
+    deps=MemoClawDeps(
+        client=MemoClaw(),
+        namespace="support",
+    ),
+    tools=[
+        memoclaw_store_tool(),
+        memoclaw_recall_tool(),
+    ],
+)
+
+response = agent.run_sync("Remember that Carla prefers morning stand-ups.")
+print(response.output)
+```
 
 ## All Methods
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 x402 = ["x402[httpx,evm]"]
 langchain = ["langchain-core>=0.2"]
 llamaindex = ["llama-index-core>=0.11"]
+pydantic-ai = ["pydantic-ai>=0.0.20"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
@@ -42,6 +43,7 @@ dev = [
     "respx>=0.22",
     "langchain-core>=0.2",
     "llama-index-core>=0.11",
+    "pydantic-ai>=0.0.20",
 ]
 
 [project.urls]

--- a/python/src/memoclaw/integrations/pydantic_ai.py
+++ b/python/src/memoclaw/integrations/pydantic_ai.py
@@ -1,0 +1,268 @@
+"""Pydantic AI integration helpers for MemoClaw.
+
+This module exposes ready-to-use tools for [Pydantic AI](https://ai.pydantic.dev)
+agents:
+
+- :func:`memoclaw_store_tool` — store memories via typed tool calls
+- :func:`memoclaw_recall_tool` — recall semantic memories from MemoClaw
+- :class:`MemoClawDeps` — dependency carrier for injecting a ``MemoClaw`` client
+
+Example::
+
+    from pydantic_ai import Agent
+    from memoclaw import MemoClaw
+    from memoclaw.integrations.pydantic_ai import (
+        MemoClawDeps,
+        memoclaw_store_tool,
+        memoclaw_recall_tool,
+    )
+
+    agent = Agent(
+        "gpt-4o-mini",
+        deps=MemoClawDeps(client=MemoClaw(), namespace="support"),
+        tools=[
+            memoclaw_store_tool(),
+            memoclaw_recall_tool(top_k=8),
+        ],
+    )
+
+    # Tools can now be called directly by the model
+    result = agent.run_sync("Remember that Maria prefers dark mode and vim")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from pydantic import BaseModel, Field
+
+try:  # pragma: no cover - exercised in import tests
+    from pydantic_ai import RunContext, Tool
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "Pydantic AI integration requires the 'pydantic-ai' package. "
+        "Install it with: pip install memoclaw[pydantic-ai]"
+    ) from exc
+
+from memoclaw.client import MemoClaw
+from memoclaw.types import MemoryType
+
+
+@dataclass(slots=True)
+class MemoClawDeps:
+    """Dependency object injected into ``RunContext.deps`` for Pydantic AI agents.
+
+    Args:
+        client: Configured :class:`~memoclaw.MemoClaw` instance.
+        namespace: Default namespace to use when a tool call omits one.
+        session_id: Default session identifier applied to store/recall calls.
+        agent_id: Default agent identifier applied to store/recall calls.
+        tags: Default tags injected into store calls when none are provided.
+    """
+
+    client: MemoClaw
+    namespace: str | None = None
+    session_id: str | None = None
+    agent_id: str | None = None
+    tags: tuple[str, ...] | None = None
+
+
+class StoreMemoryParams(BaseModel):
+    """Parameters accepted by :func:`memoclaw_store_tool`."""
+
+    model_config = {
+        "extra": "forbid",
+    }
+
+    content: str = Field(..., description="Memory content to persist.")
+    importance: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Optional importance score between 0 and 1.",
+    )
+    tags: list[str] | None = Field(
+        default=None,
+        description="Tags that categorize the memory.",
+    )
+    namespace: str | None = Field(
+        default=None,
+        description="MemoClaw namespace. Defaults to MemoClawDeps.namespace.",
+    )
+    session_id: str | None = Field(
+        default=None,
+        description="Conversation/session identifier.",
+    )
+    agent_id: str | None = Field(
+        default=None,
+        description="Agent identifier used when storing memories.",
+    )
+    memory_type: MemoryType | None = Field(
+        default=None,
+        description="Optional memory type classification (preference, fact, etc).",
+    )
+    expires_at: str | None = Field(
+        default=None,
+        description="ISO-8601 timestamp when the memory should expire.",
+    )
+    pinned: bool | None = Field(
+        default=None,
+        description="Whether the memory should be pinned as a core memory.",
+    )
+    immutable: bool | None = Field(
+        default=None,
+        description="If true, the memory cannot be modified after creation.",
+    )
+    metadata: dict[str, Any] | None = Field(
+        default=None,
+        description="Custom metadata stored alongside the memory.",
+    )
+
+
+class RecallMemoryParams(BaseModel):
+    """Parameters accepted by :func:`memoclaw_recall_tool`."""
+
+    model_config = {
+        "extra": "forbid",
+    }
+
+    query: str = Field(..., description="Semantic query to run against MemoClaw.")
+    limit: int | None = Field(
+        default=5,
+        ge=1,
+        le=50,
+        description="Maximum number of memories to return.",
+    )
+    min_similarity: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Minimum cosine similarity threshold (0-1).",
+    )
+    namespace: str | None = Field(
+        default=None,
+        description="Namespace filter. Defaults to MemoClawDeps.namespace.",
+    )
+    tags: list[str] | None = Field(
+        default=None,
+        description="Tag filter applied server-side.",
+    )
+    include_relations: bool | None = Field(
+        default=None,
+        description="Whether to include related memories in the response.",
+    )
+    session_id: str | None = Field(
+        default=None,
+        description="Session filter applied to recall.",
+    )
+    agent_id: str | None = Field(
+        default=None,
+        description="Agent filter applied to recall.",
+    )
+    after: str | None = Field(
+        default=None,
+        description="Return memories created after the given ISO timestamp.",
+    )
+    memory_type: MemoryType | None = Field(
+        default=None,
+        description="Filter by MemoClaw memory type.",
+    )
+
+
+def _merge_default(value: Any | None, fallback: Any | None) -> Any | None:
+    return value if value is not None else fallback
+
+
+def _merge_tags(
+    provided: Sequence[str] | None,
+    default: tuple[str, ...] | None,
+) -> list[str] | None:
+    if provided is not None:
+        return list(provided)
+    if default is not None:
+        return list(default)
+    return None
+
+
+def memoclaw_store_tool(
+    *,
+    name: str = "memoclaw_store_memory",
+    description: str | None = None,
+) -> Tool[MemoClawDeps]:
+    """Return a Pydantic AI tool that stores memories via :class:`MemoClaw`.
+
+    Args:
+        name: Optional tool name override.
+        description: Optional custom description exposed to the model.
+    """
+
+    def _store_memory(
+        ctx: RunContext[MemoClawDeps],
+        params: StoreMemoryParams,
+    ) -> dict[str, Any]:
+        client = ctx.deps.client
+        result = client.store(
+            params.content,
+            importance=params.importance,
+            tags=_merge_tags(params.tags, ctx.deps.tags),
+            namespace=_merge_default(params.namespace, ctx.deps.namespace),
+            session_id=_merge_default(params.session_id, ctx.deps.session_id),
+            agent_id=_merge_default(params.agent_id, ctx.deps.agent_id),
+            memory_type=params.memory_type,
+            expires_at=params.expires_at,
+            pinned=params.pinned,
+            immutable=params.immutable,
+            metadata=params.metadata,
+        )
+        return result.model_dump()
+
+    return Tool(
+        _store_memory,
+        name=name,
+        description=description
+        or "Store new long-term memories inside MemoClaw for future recall.",
+    )
+
+
+def memoclaw_recall_tool(
+    *,
+    name: str = "memoclaw_recall_memories",
+    description: str | None = None,
+) -> Tool[MemoClawDeps]:
+    """Return a Pydantic AI tool that recalls memories from MemoClaw."""
+
+    def _recall_memories(
+        ctx: RunContext[MemoClawDeps],
+        params: RecallMemoryParams,
+    ) -> dict[str, Any]:
+        client = ctx.deps.client
+        response = client.recall(
+            params.query,
+            limit=params.limit,
+            min_similarity=params.min_similarity,
+            namespace=_merge_default(params.namespace, ctx.deps.namespace),
+            tags=params.tags,
+            include_relations=params.include_relations,
+            session_id=_merge_default(params.session_id, ctx.deps.session_id),
+            agent_id=_merge_default(params.agent_id, ctx.deps.agent_id),
+            after=params.after,
+            memory_type=params.memory_type,
+        )
+        return response.model_dump()
+
+    return Tool(
+        _recall_memories,
+        name=name,
+        description=description
+        or "Recall relevant MemoClaw memories to ground conversations.",
+    )
+
+
+__all__ = [
+    "MemoClawDeps",
+    "StoreMemoryParams",
+    "RecallMemoryParams",
+    "memoclaw_store_tool",
+    "memoclaw_recall_tool",
+]

--- a/python/tests/test_pydantic_ai_integration.py
+++ b/python/tests/test_pydantic_ai_integration.py
@@ -1,0 +1,159 @@
+"""Tests for the Pydantic AI integration helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pydantic_ai = pytest.importorskip("pydantic_ai")
+from pydantic_ai import RunContext
+
+from memoclaw.integrations.pydantic_ai import (
+    MemoClawDeps,
+    RecallMemoryParams,
+    StoreMemoryParams,
+    memoclaw_recall_tool,
+    memoclaw_store_tool,
+)
+
+
+def _make_ctx(**deps_kwargs: object) -> RunContext[MemoClawDeps]:
+    deps = MemoClawDeps(**deps_kwargs)
+    return RunContext(deps=deps, model=MagicMock(), usage=MagicMock())
+
+
+class TestStoreTool:
+    def test_store_uses_defaults(self):
+        client = MagicMock()
+        client.store.return_value.model_dump.return_value = {"id": "mem-123"}
+
+        tool = memoclaw_store_tool()
+        ctx = _make_ctx(
+            client=client,
+            namespace="support",
+            session_id="sess-1",
+            agent_id="agent-7",
+            tags=("default",),
+        )
+
+        payload = StoreMemoryParams(content="User prefers dark mode")
+        result = tool.function(ctx, payload)
+
+        assert result == {"id": "mem-123"}
+        client.store.assert_called_once_with(
+            "User prefers dark mode",
+            importance=None,
+            tags=["default"],
+            namespace="support",
+            session_id="sess-1",
+            agent_id="agent-7",
+            memory_type=None,
+            expires_at=None,
+            pinned=None,
+            immutable=None,
+            metadata=None,
+        )
+
+    def test_store_overrides_defaults(self):
+        client = MagicMock()
+        client.store.return_value.model_dump.return_value = {"id": "mem-456"}
+
+        tool = memoclaw_store_tool()
+        ctx = _make_ctx(client=client, namespace="support", tags=("default",))
+
+        payload = StoreMemoryParams(
+            content="Important fact",
+            namespace="research",
+            tags=["custom"],
+            importance=0.9,
+            session_id="sess-2",
+            agent_id="agent-9",
+            pinned=True,
+            metadata={"topic": "ux"},
+        )
+        tool.function(ctx, payload)
+
+        client.store.assert_called_once_with(
+            "Important fact",
+            importance=0.9,
+            tags=["custom"],
+            namespace="research",
+            session_id="sess-2",
+            agent_id="agent-9",
+            memory_type=None,
+            expires_at=None,
+            pinned=True,
+            immutable=None,
+            metadata={"topic": "ux"},
+        )
+
+
+class TestRecallTool:
+    def test_recall_uses_defaults(self):
+        client = MagicMock()
+        client.recall.return_value.model_dump.return_value = {
+            "memories": [],
+            "query_tokens": 12,
+        }
+
+        tool = memoclaw_recall_tool()
+        ctx = _make_ctx(
+            client=client,
+            namespace="support",
+            session_id="sess-1",
+            agent_id="agent-7",
+        )
+
+        payload = RecallMemoryParams(query="preferences")
+        result = tool.function(ctx, payload)
+
+        assert result["memories"] == []
+        client.recall.assert_called_once_with(
+            "preferences",
+            limit=5,
+            min_similarity=None,
+            namespace="support",
+            tags=None,
+            include_relations=None,
+            session_id="sess-1",
+            agent_id="agent-7",
+            after=None,
+            memory_type=None,
+        )
+
+    def test_recall_overrides(self):
+        client = MagicMock()
+        client.recall.return_value.model_dump.return_value = {
+            "memories": [
+                {"id": "mem-1", "content": "something"},
+            ],
+            "query_tokens": 5,
+        }
+
+        tool = memoclaw_recall_tool(name="custom_name")
+        ctx = _make_ctx(client=client, namespace="support")
+
+        payload = RecallMemoryParams(
+            query="recent decisions",
+            limit=10,
+            tags=["decisions"],
+            include_relations=True,
+            namespace="product",
+            after="2026-03-01T00:00:00Z",
+        )
+        result = tool.function(ctx, payload)
+
+        assert result["memories"][0]["id"] == "mem-1"
+        client.recall.assert_called_once_with(
+            "recent decisions",
+            limit=10,
+            min_similarity=None,
+            namespace="product",
+            tags=["decisions"],
+            include_relations=True,
+            session_id=None,
+            agent_id=None,
+            after="2026-03-01T00:00:00Z",
+            memory_type=None,
+        )


### PR DESCRIPTION
## Summary
- add optional 'pydantic-ai' extra and README docs for the new integration
- expose MemoClawDeps plus typed store/recall tools for Pydantic AI agents
- cover the new tools with unit tests

## Testing
- pytest tests/test_pydantic_ai_integration.py

Fixes #213