### PR TITLE
feat(python): add CrewAI integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to memoclaw-sdk will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- CrewAI integration with `MemoClawStoreTool` and `MemoClawRecallTool` for Python SDK (#211)
+
 ## [1.1.0] - 2026-03-19
 
 ### Features

--- a/python/README.md
+++ b/python/README.md
@@ -119,6 +119,41 @@ response = agent.run_sync("Remember that Carla prefers morning stand-ups.")
 print(response.output)
 ```
 
+## CrewAI Integration
+
+Install the extra dependencies and add MemoClaw tools to your CrewAI agents.
+
+```bash
+pip install memoclaw[crewai]
+```
+
+```python
+from crewai import Agent, Task, Crew
+from memoclaw import MemoClaw
+from memoclaw.integrations.crewai import MemoClawStoreTool, MemoClawRecallTool
+
+client = MemoClaw(private_key="0x...")
+
+store_tool = MemoClawStoreTool(client=client, namespace="support")
+recall_tool = MemoClawRecallTool(client=client, namespace="support")
+
+agent = Agent(
+    role="Support Agent",
+    goal="Help users and remember their preferences",
+    backstory="You are a helpful support agent with long-term memory.",
+    tools=[store_tool, recall_tool],
+)
+
+task = Task(
+    description="Remember that the user prefers dark mode.",
+    agent=agent,
+    expected_output="Confirmation that the preference was stored.",
+)
+
+crew = Crew(agents=[agent], tasks=[task])
+result = crew.kickoff()
+```
+
 ## All Methods
 
 | Method | Description |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,6 +36,7 @@ x402 = ["x402[httpx,evm]"]
 langchain = ["langchain-core>=0.2"]
 llamaindex = ["llama-index-core>=0.11"]
 pydantic-ai = ["pydantic-ai>=0.0.20"]
+crewai = ["crewai>=0.80"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",

--- a/python/src/memoclaw/integrations/crewai.py
+++ b/python/src/memoclaw/integrations/crewai.py
@@ -1,0 +1,193 @@
+"""CrewAI integration for MemoClaw.
+
+Provides:
+- :class:`MemoClawStoreTool` — CrewAI tool for storing memories
+- :class:`MemoClawRecallTool` — CrewAI tool for recalling memories
+
+Install with::
+
+    pip install memoclaw[crewai]
+
+Example::
+
+    from crewai import Agent, Task, Crew
+    from memoclaw import MemoClaw
+    from memoclaw.integrations.crewai import MemoClawStoreTool, MemoClawRecallTool
+
+    client = MemoClaw(private_key="0x...")
+
+    store_tool = MemoClawStoreTool(client=client, namespace="support")
+    recall_tool = MemoClawRecallTool(client=client, namespace="support")
+
+    agent = Agent(
+        role="Support Agent",
+        goal="Help users and remember their preferences",
+        backstory="You are a helpful support agent with long-term memory.",
+        tools=[store_tool, recall_tool],
+    )
+
+    task = Task(
+        description="Remember that the user prefers dark mode.",
+        agent=agent,
+        expected_output="Confirmation that the preference was stored.",
+    )
+
+    crew = Crew(agents=[agent], tasks=[task])
+    result = crew.kickoff()
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Type
+
+from pydantic import BaseModel, Field
+
+try:
+    from crewai.tools import BaseTool
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "CrewAI integration requires the 'crewai' package. "
+        "Install it with: pip install memoclaw[crewai]"
+    ) from exc
+
+from memoclaw.client import MemoClaw
+
+
+class _StoreMemoryInput(BaseModel):
+    """Input schema for the MemoClaw store tool."""
+
+    content: str = Field(..., description="The memory content to store.")
+    importance: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Importance score between 0 and 1. Higher = more important.",
+    )
+    tags: list[str] | None = Field(
+        default=None,
+        description="Tags to categorize the memory.",
+    )
+
+
+class _RecallMemoryInput(BaseModel):
+    """Input schema for the MemoClaw recall tool."""
+
+    query: str = Field(..., description="Natural language query to search memories.")
+    limit: int = Field(
+        default=5,
+        ge=1,
+        le=50,
+        description="Maximum number of memories to return.",
+    )
+    min_similarity: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Minimum similarity threshold (0-1).",
+    )
+    tags: list[str] | None = Field(
+        default=None,
+        description="Filter results to memories with these tags.",
+    )
+
+
+class MemoClawStoreTool(BaseTool):
+    """CrewAI tool that stores memories in MemoClaw.
+
+    Args:
+        client: A configured :class:`~memoclaw.MemoClaw` instance.
+        namespace: Default namespace for stored memories.
+        session_id: Default session identifier.
+        agent_id: Default agent identifier.
+        default_tags: Tags applied to every store call when none are provided.
+        name: Tool name exposed to the agent.
+        description: Tool description exposed to the agent.
+    """
+
+    name: str = "memoclaw_store_memory"
+    description: str = (
+        "Store a piece of information in long-term memory for future recall. "
+        "Use this when the user shares preferences, facts, corrections, or anything "
+        "worth remembering across conversations."
+    )
+    args_schema: Type[BaseModel] = _StoreMemoryInput
+
+    # Instance config — not exposed to the LLM
+    client: Any = Field(exclude=True)
+    namespace: str | None = Field(default=None, exclude=True)
+    session_id: str | None = Field(default=None, exclude=True)
+    agent_id: str | None = Field(default=None, exclude=True)
+    default_tags: list[str] | None = Field(default=None, exclude=True)
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    def _run(
+        self,
+        content: str,
+        importance: float | None = None,
+        tags: list[str] | None = None,
+    ) -> str:
+        resolved_tags = tags if tags is not None else self.default_tags
+        result = self.client.store(
+            content,
+            importance=importance,
+            tags=resolved_tags,
+            namespace=self.namespace,
+            session_id=self.session_id,
+            agent_id=self.agent_id,
+        )
+        return json.dumps(result.model_dump(), default=str)
+
+
+class MemoClawRecallTool(BaseTool):
+    """CrewAI tool that recalls memories from MemoClaw.
+
+    Args:
+        client: A configured :class:`~memoclaw.MemoClaw` instance.
+        namespace: Default namespace to search.
+        session_id: Default session filter.
+        agent_id: Default agent filter.
+        name: Tool name exposed to the agent.
+        description: Tool description exposed to the agent.
+    """
+
+    name: str = "memoclaw_recall_memories"
+    description: str = (
+        "Search long-term memory for information relevant to a query. "
+        "Use this to retrieve previously stored facts, preferences, or context "
+        "before answering questions."
+    )
+    args_schema: Type[BaseModel] = _RecallMemoryInput
+
+    # Instance config
+    client: Any = Field(exclude=True)
+    namespace: str | None = Field(default=None, exclude=True)
+    session_id: str | None = Field(default=None, exclude=True)
+    agent_id: str | None = Field(default=None, exclude=True)
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    def _run(
+        self,
+        query: str,
+        limit: int = 5,
+        min_similarity: float | None = None,
+        tags: list[str] | None = None,
+    ) -> str:
+        response = self.client.recall(
+            query,
+            limit=limit,
+            min_similarity=min_similarity,
+            namespace=self.namespace,
+            tags=tags,
+            session_id=self.session_id,
+            agent_id=self.agent_id,
+        )
+        return json.dumps(response.model_dump(), default=str)
+
+
+__all__ = [
+    "MemoClawStoreTool",
+    "MemoClawRecallTool",
+]

--- a/python/src/memoclaw/integrations/crewai.py
+++ b/python/src/memoclaw/integrations/crewai.py
@@ -92,7 +92,7 @@ class _RecallMemoryInput(BaseModel):
     )
 
 
-class MemoClawStoreTool(BaseTool):
+class MemoClawStoreTool(BaseTool):  # type: ignore[misc]
     """CrewAI tool that stores memories in MemoClaw.
 
     Args:
@@ -140,7 +140,7 @@ class MemoClawStoreTool(BaseTool):
         return json.dumps(result.model_dump(), default=str)
 
 
-class MemoClawRecallTool(BaseTool):
+class MemoClawRecallTool(BaseTool):  # type: ignore[misc]
     """CrewAI tool that recalls memories from MemoClaw.
 
     Args:

--- a/python/tests/test_crewai_integration.py
+++ b/python/tests/test_crewai_integration.py
@@ -1,0 +1,281 @@
+"""Tests for the CrewAI integration module.
+
+These tests mock the crewai dependency so we don't need it installed at test time.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Mock crewai.tools.BaseTool before importing the integration module
+# ---------------------------------------------------------------------------
+
+class _FakeBaseTool:
+    """Minimal stand-in for crewai.tools.BaseTool."""
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+@pytest.fixture(autouse=True)
+def _mock_crewai(monkeypatch):
+    """Inject a fake crewai module so the integration can be imported."""
+    crewai_mod = types.ModuleType("crewai")
+    tools_mod = types.ModuleType("crewai.tools")
+
+    # We need BaseTool to be a proper Pydantic-compatible base.
+    # Since the real integration uses Pydantic model features, we use a
+    # minimal shim that the Pydantic metaclass can work with.
+    from pydantic import BaseModel
+
+    class FakeBaseTool(BaseModel):
+        """Minimal shim matching the crewai BaseTool interface."""
+
+        model_config = {"arbitrary_types_allowed": True}
+
+    tools_mod.BaseTool = FakeBaseTool
+    crewai_mod.tools = tools_mod
+
+    monkeypatch.setitem(sys.modules, "crewai", crewai_mod)
+    monkeypatch.setitem(sys.modules, "crewai.tools", tools_mod)
+
+    yield
+
+    # Clean up cached import of our integration module so each test is fresh
+    sys.modules.pop("memoclaw.integrations.crewai", None)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_store_response(**overrides):
+    """Return a mock store response."""
+    defaults = {
+        "id": "mem_abc123",
+        "content": "test content",
+        "importance": 0.8,
+        "tags": ["test"],
+        "namespace": "default",
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    mock.model_dump.return_value = defaults
+    return mock
+
+
+def _make_recall_response(memories=None):
+    """Return a mock recall response."""
+    mock = MagicMock()
+    mock.model_dump.return_value = {
+        "memories": memories or [],
+        "query": "test query",
+        "total": len(memories or []),
+    }
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Store tool tests
+# ---------------------------------------------------------------------------
+
+class TestMemoClawStoreTool:
+    def test_store_basic(self):
+        from memoclaw.integrations.crewai import MemoClawStoreTool
+
+        client = MagicMock()
+        client.store.return_value = _make_store_response()
+
+        tool = MemoClawStoreTool(client=client, namespace="test-ns")
+        result = tool._run(content="User likes dark mode")
+
+        client.store.assert_called_once_with(
+            "User likes dark mode",
+            importance=None,
+            tags=None,
+            namespace="test-ns",
+            session_id=None,
+            agent_id=None,
+        )
+        parsed = json.loads(result)
+        assert parsed["id"] == "mem_abc123"
+
+    def test_store_with_importance_and_tags(self):
+        from memoclaw.integrations.crewai import MemoClawStoreTool
+
+        client = MagicMock()
+        client.store.return_value = _make_store_response(importance=0.9, tags=["pref"])
+
+        tool = MemoClawStoreTool(client=client)
+        result = tool._run(content="Prefers vim", importance=0.9, tags=["pref"])
+
+        client.store.assert_called_once_with(
+            "Prefers vim",
+            importance=0.9,
+            tags=["pref"],
+            namespace=None,
+            session_id=None,
+            agent_id=None,
+        )
+        parsed = json.loads(result)
+        assert parsed["importance"] == 0.9
+
+    def test_store_uses_default_tags(self):
+        from memoclaw.integrations.crewai import MemoClawStoreTool
+
+        client = MagicMock()
+        client.store.return_value = _make_store_response()
+
+        tool = MemoClawStoreTool(
+            client=client,
+            default_tags=["auto", "agent"],
+        )
+        tool._run(content="Some fact")
+
+        call_kwargs = client.store.call_args
+        assert call_kwargs.kwargs.get("tags") == ["auto", "agent"] or \
+               call_kwargs[1].get("tags") == ["auto", "agent"]
+
+    def test_store_explicit_tags_override_defaults(self):
+        from memoclaw.integrations.crewai import MemoClawStoreTool
+
+        client = MagicMock()
+        client.store.return_value = _make_store_response()
+
+        tool = MemoClawStoreTool(
+            client=client,
+            default_tags=["auto"],
+        )
+        tool._run(content="Some fact", tags=["explicit"])
+
+        call_kwargs = client.store.call_args
+        assert call_kwargs.kwargs.get("tags") == ["explicit"] or \
+               call_kwargs[1].get("tags") == ["explicit"]
+
+    def test_store_passes_session_and_agent_ids(self):
+        from memoclaw.integrations.crewai import MemoClawStoreTool
+
+        client = MagicMock()
+        client.store.return_value = _make_store_response()
+
+        tool = MemoClawStoreTool(
+            client=client,
+            session_id="sess-1",
+            agent_id="agent-1",
+        )
+        tool._run(content="test")
+
+        _, kwargs = client.store.call_args
+        assert kwargs["session_id"] == "sess-1"
+        assert kwargs["agent_id"] == "agent-1"
+
+
+# ---------------------------------------------------------------------------
+# Recall tool tests
+# ---------------------------------------------------------------------------
+
+class TestMemoClawRecallTool:
+    def test_recall_basic(self):
+        from memoclaw.integrations.crewai import MemoClawRecallTool
+
+        memories = [
+            {"id": "mem_1", "content": "Likes dark mode", "similarity": 0.92},
+        ]
+        client = MagicMock()
+        client.recall.return_value = _make_recall_response(memories)
+
+        tool = MemoClawRecallTool(client=client, namespace="test-ns")
+        result = tool._run(query="user preferences")
+
+        client.recall.assert_called_once_with(
+            "user preferences",
+            limit=5,
+            min_similarity=None,
+            namespace="test-ns",
+            tags=None,
+            session_id=None,
+            agent_id=None,
+        )
+        parsed = json.loads(result)
+        assert len(parsed["memories"]) == 1
+
+    def test_recall_with_filters(self):
+        from memoclaw.integrations.crewai import MemoClawRecallTool
+
+        client = MagicMock()
+        client.recall.return_value = _make_recall_response([])
+
+        tool = MemoClawRecallTool(client=client)
+        tool._run(
+            query="preferences",
+            limit=10,
+            min_similarity=0.8,
+            tags=["pref"],
+        )
+
+        client.recall.assert_called_once_with(
+            "preferences",
+            limit=10,
+            min_similarity=0.8,
+            namespace=None,
+            tags=["pref"],
+            session_id=None,
+            agent_id=None,
+        )
+
+    def test_recall_passes_session_and_agent_ids(self):
+        from memoclaw.integrations.crewai import MemoClawRecallTool
+
+        client = MagicMock()
+        client.recall.return_value = _make_recall_response([])
+
+        tool = MemoClawRecallTool(
+            client=client,
+            session_id="sess-2",
+            agent_id="agent-2",
+        )
+        tool._run(query="test")
+
+        _, kwargs = client.recall.call_args
+        assert kwargs["session_id"] == "sess-2"
+        assert kwargs["agent_id"] == "agent-2"
+
+    def test_recall_custom_name_and_description(self):
+        from memoclaw.integrations.crewai import MemoClawRecallTool
+
+        client = MagicMock()
+        tool = MemoClawRecallTool(
+            client=client,
+            name="custom_recall",
+            description="Custom desc",
+        )
+        assert tool.name == "custom_recall"
+        assert tool.description == "Custom desc"
+
+
+# ---------------------------------------------------------------------------
+# Import guard test
+# ---------------------------------------------------------------------------
+
+class TestImportGuard:
+    def test_raises_without_crewai(self, monkeypatch):
+        """When crewai is not installed, importing should raise ImportError."""
+        # Remove the mocked crewai modules
+        monkeypatch.delitem(sys.modules, "crewai", raising=False)
+        monkeypatch.delitem(sys.modules, "crewai.tools", raising=False)
+        sys.modules.pop("memoclaw.integrations.crewai", None)
+
+        with pytest.raises(ImportError, match="crewai"):
+            from memoclaw.integrations.crewai import MemoClawStoreTool  # noqa: F401


### PR DESCRIPTION
## Summary

Adds CrewAI integration to the Python SDK, closing the competitive gap with Mem0.

### Changes
- `MemoClawStoreTool` — CrewAI `BaseTool` subclass for storing memories with importance, tags, namespace, session/agent IDs, and default tag support
- `MemoClawRecallTool` — CrewAI `BaseTool` subclass for semantic recall with limit, min_similarity, tag filters, session/agent IDs
- Optional dependency: `pip install memoclaw[crewai]` (`crewai>=0.80`)
- 10 tests with mocked crewai (no crewai import required at test time)
- Documentation and example in Python README
- CHANGELOG entry

### Example
```python
from crewai import Agent, Task, Crew
from memoclaw import MemoClaw
from memoclaw.integrations.crewai import MemoClawStoreTool, MemoClawRecallTool

client = MemoClaw(private_key="0x...")
store_tool = MemoClawStoreTool(client=client, namespace="support")
recall_tool = MemoClawRecallTool(client=client, namespace="support")

agent = Agent(
    role="Support Agent",
    goal="Help users and remember their preferences",
    tools=[store_tool, recall_tool],
)
```

Fixes #211