### PR TITLE
fix(ts): ensure onError runs for transport failures

### DIFF
--- a/typescript/src/__tests__/client.test.ts
+++ b/typescript/src/__tests__/client.test.ts
@@ -427,6 +427,23 @@ describe('Hooks', () => {
     expect(hook).toHaveBeenCalledWith('GET', '/v1/memories/x', expect.any(NotFoundError));
   });
 
+  it('calls onError hook on terminal transport error', async () => {
+    const f = vi.fn(async () => {
+      throw new Error('socket closed');
+    });
+    const hook = vi.fn();
+    const client = createClient(f).onError(hook);
+
+    await expect(client.status()).rejects.toMatchObject({
+      name: 'MemoClawError',
+      code: 'TRANSPORT_ERROR',
+      status: 0,
+      message: 'socket closed',
+    });
+
+    expect(hook).toHaveBeenCalledWith('GET', '/v1/free-tier/status', expect.any(MemoClawError));
+  });
+
   it('beforeRequest can modify body', async () => {
     const f = mockFetch([{ status: 201, body: { id: 'x', stored: true, deduplicated: false, tokens_used: 1 } }]);
     const client = createClient(f).onBeforeRequest((_method, _path, body) => {

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -686,8 +686,21 @@ export class MemoClawClient {
         }
         throw lastError!;
       } catch (err) {
-        tracing.recordError(err as Error);
-        throw err;
+        if (err instanceof MemoClawError) {
+          tracing.recordError(err);
+          throw err;
+        }
+
+        const transportMessage = err instanceof Error ? err.message : String(err);
+        const transportError = new MemoClawError(
+          0,
+          'TRANSPORT_ERROR',
+          transportMessage || 'Transport error',
+          err instanceof Error ? { name: err.name } : undefined,
+        );
+        await this.emitErrorHooks(method, path, transportError);
+        tracing.recordError(transportError);
+        throw transportError;
       }
     });
   }


### PR DESCRIPTION
## Summary
- normalize non-MemoClaw transport exceptions in request() into MemoClawError (`TRANSPORT_ERROR`, status `0`)
- invoke emitErrorHooks() in the outer catch for terminal transport failures
- add a regression test asserting onError is called when fetch throws

## Testing
- `cd typescript && npm test`

Fixes #221
